### PR TITLE
Add video support

### DIFF
--- a/header.lua
+++ b/header.lua
@@ -14,6 +14,7 @@ require("playdate.sound")
 require("playdate.easing")
 require("playdate.frameTimer")
 require("playdate.timer")
+require("playdate.video")
 
 function import(path)
   if string.match(path, "^CoreLibs/") then

--- a/playbit/util.lua
+++ b/playbit/util.lua
@@ -24,3 +24,48 @@ function module.sign(a)
     return 0
   end
 end
+
+-- Decode chars from a string buffer at given pos
+function module.readChars(data, dataSize, pos, size)
+  @@ASSERT(pos + size <= dataSize, "Failed to load data, chars out of range at pos: " .. pos)
+  return string.sub(data, pos + 1, pos + size)
+end
+
+-- Decode 8-bit unsigned int from a string buffer at given pos
+function module.readUInt8(data, dataSize, pos)
+  @@ASSERT(pos + 1 <= dataSize, "Failed to load data, uint8 out of range at pos: " .. pos)
+  local b1 = string.byte(data, pos + 1)
+  return b1
+end
+
+-- Decode 16-bit signed int from a string buffer at given pos
+function module.readInt16(data, dataSize, pos)
+  @@ASSERT(pos + 2 <= dataSize, "Failed to load data, int16 out of range at pos: " .. pos)
+  local b1, b2 = string.byte(data, pos + 1, pos + 2)
+  return b2 * 256 + b1
+end
+
+-- Decode 32-bit unsigned int from a string buffer at given pos
+function module.readUInt32(data, dataSize, pos)
+  @@ASSERT(pos + 4 <= dataSize, "Failed to load data, uint32 out of range at pos: " .. pos)
+  local b1, b2, b3, b4 = string.byte(data, pos + 1, pos + 4)
+  return b1 + b2 * 0x100 + b3 * 0x10000 + b4 * 0x1000000
+end
+
+-- Decode 32-bit float from a string buffer at given pos
+function module.readFloat32(data, dataSize, pos)
+  @@ASSERT(pos + 4 <= dataSize, "Failed to load data, float32 out of range at pos: " .. pos)
+  local b1, b2, b3, b4 = string.byte(data, pos + 1, pos + 4)
+
+  local exponent = (b4 % 128) * 2 + math.floor(b3 / 128)
+  if exponent == 0 then return 0 end
+  
+  local sign = 1
+  if b4 > 127 then sign = -1 end
+  
+  local mantissa = (b3 % 128)
+  mantissa = mantissa * 256 + b2
+  mantissa = mantissa * 256 + b1
+  mantissa = (math.ldexp(mantissa, -23) + 1) * sign
+  return math.ldexp(mantissa, exponent - 127)
+end

--- a/playdate/graphics.lua
+++ b/playdate/graphics.lua
@@ -35,6 +35,17 @@ kTextAlignment = {
 	center = 2,
 }
 
+---Converts playdate color into love rendering color.
+---@return color
+function module.getLoveColor(color)
+  @@ASSERT(color == 1 or color == 0, "Only values of 0 (black) or 1 (white) are supported.")
+  if color == 1 then
+    return COLOR_WHITE
+  else
+    return COLOR_BLACK
+  end
+end
+
 function module.setDrawOffset(x, y)
   module._drawOffset.x = x
   module._drawOffset.y = y

--- a/playdate/image.lua
+++ b/playdate/image.lua
@@ -5,6 +5,12 @@ local meta = {}
 meta.__index = meta
 module.__index = meta
 
+function module.newFromData(imageData)
+  local img = setmetatable({}, meta)
+  img.data = love.graphics.newImage(imageData)
+  return img
+end
+
 function module.new(widthOrPath, height, bgcolor)
   @@ASSERT(bgcolor == nil, "Parameter 'bgcolor' is not implemented.")
   local img = setmetatable({}, meta)

--- a/playdate/video.lua
+++ b/playdate/video.lua
@@ -1,0 +1,164 @@
+local module = {}
+playdate.graphics.video = module
+
+local meta = {}
+meta.__index = meta
+module.__index = meta
+
+require("playbit.util")
+
+local function loadFrameData(vid, number)
+  @@ASSERT(number > 0 and number <= vid.frameCount, "Invalid frame number: " .. number)
+  
+  local bufferCompressed = vid.imageBuffers[number]
+  local bufferRaw = love.data.decompress("string", "zlib", bufferCompressed)
+  
+  local imageData = love.image.newImageData(vid.width, vid.height)
+  local fillColorWhite = playdate.graphics.getLoveColor(1)
+  local fillColorBlack = playdate.graphics.getLoveColor(0)
+  
+  local charWidth = vid.width / 8
+  local bufferSize = charWidth * vid.height
+  for y = 0, vid.height - 1 do
+    for xchar = 0, charWidth - 1 do
+	  -- Ready 8 pixels at once
+	  local chunkIndex = y * charWidth + (charWidth - xchar - 1)
+	  local chunk = playbit.util.readUInt8(bufferRaw, bufferSize, chunkIndex)
+	  for shift = 0, 7 do
+	    x = vid.width - (xchar * 8 + shift) - 1
+		local isWhite = (bit.band(bit.rshift(chunk, shift), 0x1) == 0x1)
+		if isWhite then
+	      imageData:setPixel(x, y, fillColorWhite.r, fillColorWhite.g, fillColorWhite.b, 1)
+		else
+	      imageData:setPixel(x, y, fillColorBlack.r, fillColorBlack.g, fillColorBlack.b, 1)
+		end
+      end
+	end
+  end
+  vid.images[number] = playdate.graphics.image.newFromData(imageData)
+end
+
+function module.new(path)
+  local data, dataSize = love.filesystem.read(path)
+  @@ASSERT(data, "Failed to load video data.")
+  
+  -- Read header
+  local headerStr = playbit.util.readChars(data, dataSize, 0, 12)
+  @@ASSERT(headerStr == "Playdate VID", "Invalid video data header: " .. headerStr)
+  
+  local reserved1 = playbit.util.readUInt32(data, dataSize, 12)
+  @@ASSERT(reserved1 == 0, "Expected 0 for reserved value: " .. reserved1)
+  
+  -- Read main info
+  local frameCount = playbit.util.readInt16(data, dataSize, 16)
+  @@ASSERT(frameCount > 0, "Invalid video frame count: " .. frameCount)
+  
+  local reserved2 = playbit.util.readInt16(data, dataSize, 18)
+  @@ASSERT(reserved2 == 0, "Expected 0 for reserved value: " .. reserved2)
+  
+  local frameRate = playbit.util.readFloat32(data, dataSize, 20)
+  @@ASSERT(frameRate > 0, "Invalid video frame rate: " .. frameRate)
+  
+  local width = playbit.util.readInt16(data, dataSize, 24)
+  @@ASSERT(width == 400, "Invalid video width: " .. width)
+  
+  local height = playbit.util.readInt16(data, dataSize, 26)
+  @@ASSERT(height == 240, "Invalid video height: " .. height)
+  
+  local vid = setmetatable({}, meta)
+  vid.width = width
+  vid.height = height
+  vid.frameCount = frameCount
+  vid.frameRate = frameRate
+  vid.imageBuffers = {}
+  vid.images = {}
+  vid.context = nil
+  
+  -- Read frame table
+  local tableTypes = {}
+  local tableOffsets = {}
+  local baseOffset = 28 + (frameCount + 1) * 4
+  for i = 0, frameCount do
+    local v = playbit.util.readUInt32(data, dataSize, 28 + i * 4)
+    local type = bit.band(v, 0x3)
+    local offset = bit.rshift(v, 2)
+	@@ASSERT(type == 1 or type == 0, "Unsupported frame type: " .. type)
+	@@ASSERT(type ~= 0 or i == frameCount, "Invalid null frame before end-of-file")
+	@@ASSERT(offset + baseOffset <= dataSize, "Invalid frame offset: " .. offset)
+    tableTypes[i + 1] = type
+    tableOffsets[i + 1] = offset + baseOffset
+  end
+  @@ASSERT(tableTypes[frameCount + 1] == 0, "Invalid end-of-file offset type: " .. tableTypes[frameCount + 1])
+  @@ASSERT(tableOffsets[frameCount + 1] == dataSize, "Invalid end-of-file offset: " .. tableOffsets[frameCount + 1])
+  
+  -- TODO: add support for P-frame (type 2) and combined frame (type 3)
+  
+  -- Read frame data
+  for f = 1, frameCount do
+    local startOffset = tableOffsets[f]
+    local endOffset = tableOffsets[f + 1]
+    
+	local bufferSizeCompressed = endOffset - startOffset
+	local bufferCompressed = playbit.util.readChars(data, dataSize, startOffset, bufferSizeCompressed)
+	@@ASSERT(bufferCompressed, "Invalid frame data for frame: " .. f)
+	
+    vid.imageBuffers[f] = playbit.util.readChars(data, dataSize, startOffset, bufferSizeCompressed)
+  end
+  
+  return vid
+end
+
+function meta:getSize()
+  return self.width, self.height
+end
+
+function meta:getFrameCount()
+  return self.frameCount
+end
+
+function meta:getFrameRate()
+  return self.frameRate
+end
+
+function meta:setContext(image)
+  self.context = image
+end
+
+function meta:getContext()
+  -- create image context if it doesn't exist
+  if self.context == nil then
+    self.context = playdate.graphics.image.new(self.width, self.height)
+  end
+  
+  return self.context
+end
+
+function meta:useScreenContext()
+  -- reset image context if it exists
+  self.context = nil
+end
+
+function meta:renderFrame(number)
+  @@ASSERT(number > 0 and number <= self.frameCount, "Invalid frame number: " .. number)
+  
+  -- load frame data if needed
+  if self.images[number] == nil then
+    loadFrameData(self, number)
+  end
+  
+  if self.context then
+    -- render into image context
+	playdate.graphics.pushContext(self.context)
+    self.images[number]:draw(0, 0)
+	playdate.graphics.popContext()
+  else
+    -- directly render frame
+    self.images[number]:draw(0, 0)
+  end
+  
+  -- reset frame data
+  self.images[number] = nil
+  
+  -- Force releasing image data to avoid memory leaks
+  collectgarbage('collect')
+end


### PR DESCRIPTION
Implemented a basic version of video playback support based on .pdv format.

Notes:
- Supports rendering into screen or an image context
- Supports only l-frames playback, not P-frames or combined frames which can be added for optimization purpose.

### **Resources:**

Specifications for .pdv format
https://github.com/cranksters/playdate-reverse-engineering/blob/main/formats/pdv.md

Typescript implementation with P-frame support
https://gist.github.com/jaames/7dfe0fcd24954e70b180e648be955ae8