### PR TITLE
Fixed font files not being converted if they didn't have exactly 16 characters per row

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,17 +24,18 @@ The following are not required for _general_ use of Playbit, but required if you
 
 ## Setup your environment
 1. Add the `PLAYDATE_SDK_PATH` to your environment variables. For more information, see Panic's documentation on how to [set the Playdate SDK variable](https://sdk.play.date/Inside%20Playdate.html#_set_playdate_sdk_path_environment_variable).
-1. Add Lua to your `Path` environment variable.
-2. Add Love2d to your `Path` environment variable.
+2. Add Lua to your `Path` environment variable.
+3. Add Love2d to your `Path` environment variable.
 
 If you're using any [optional dependencies](#optional) you'll also need to add them to your `Path` environment variable, unless you specify the path to the executable when setting up [file processors](file-processors.md).
 
 ## Next steps
 1. [Read about Playbit's limitations](limitations.md)
-1. [Learn about core concepts](core-concepts.md)
-1. [Add Playbit to your project](add-playbit.md)
-1. [Configure build scripts](build-scripts.md)
-1. [Build & run your project](build-and-run.md)
+2. [Learn about core concepts](core-concepts.md)
+3. [Add Playbit to your project](add-playbit.md)
+4. [Add metadata to your fonts](add-font-metadata.md)
+5. [Configure build scripts](build-scripts.md)
+6. [Build & run your project](build-and-run.md)
 
 ## Get help
 If you find a bug, missing documentation, or have trouble setting up playbit, [open an issue](https://github.com/GamesRightMeow/playbit/issues).

--- a/docs/modify-fonts.md
+++ b/docs/modify-fonts.md
@@ -1,0 +1,35 @@
+# Add metadata to your fonts
+
+Playdate's `.fnt` format is not compatible with Love2D's `.fnt` format out of the box. Playdate uses [a custom format designed for use with Caps](https://sdk.play.date/1.9.3/Inside%20Playdate.html#_text), where as Love2D's uses the standard [BMFont](https://www.angelcode.com/products/bmfont/doc/file_format.html) format.
+
+Playbit automatically handles _most_ of this conversion for you. However there are a few things that can't be automatically detected, so you'll need to add additional keys to your fonts.
+
+- `playbit_width`: the width of your font's image (not the glyph).
+- `playbit_height`: the height of your font's image (again, not the glyph).
+
+For example, the SDK-provide font `Asheville-Mono-Light-24-px.fnt` starts like this:
+
+```
+space	14
+!		14
+"		14
+#		14
+$		14
+%		14
+
+and etc..
+```
+
+You can add the playbit keys anywhere in the file, like so:
+```
+playbit_width=512
+playbit_height=256
+space	14
+!		14
+"		14
+#		14
+$		14
+%		14
+
+and etc..
+```

--- a/tools/caps-to-bmfont.lua
+++ b/tools/caps-to-bmfont.lua
@@ -37,6 +37,12 @@ function isAscii(char)
 end
 
 function parseLine(line, inputData)
+  local start, ends = string.find(line, "%-%-")
+  if (start and ends) then
+    -- ignore comments
+    return
+  end
+  
   local start, ends = string.find(line, "tracking=")
   if (start and ends) then
     inputData.tracking = string.sub(line, ends+1)

--- a/tools/caps-to-bmfont.lua
+++ b/tools/caps-to-bmfont.lua
@@ -56,6 +56,11 @@ function parseLine(line, inputData)
   local char1 = string.sub(line, 1, 1)
   local char2 = string.sub(line, 2, 2)
 
+  if #char1 == 0 or #char2 == 0 then
+    -- ignore empty line
+    return
+  end
+
   if isWhitespace(char2) then  
     -- if second char is whitespace, we can assume this line is a glyph
     if isAscii(char1) then

--- a/tools/caps-to-bmfont.lua
+++ b/tools/caps-to-bmfont.lua
@@ -24,6 +24,9 @@ end
 
 function isAscii(char)
   local code = string.byte(char)
+  if #char == 0 then
+    error("function was given a nil char")
+  end
 
   -- space to tilde
   if (code >= 32 and code <= 126) then

--- a/tools/caps-to-bmfont.lua
+++ b/tools/caps-to-bmfont.lua
@@ -142,7 +142,7 @@ function convert(inputFntPath, outputFntPath)
     kerning = {},
     name = "",
     texWidth = 0,
-    textHeight = 0
+    texHeight = 0
   }
 
   -- find atlas based on .fnt path
@@ -177,7 +177,7 @@ function convert(inputFntPath, outputFntPath)
   end
 
   input.texWidth = input.tileWidth * 16
-  input.textHeight = input.tileHeight * math.floor(#input.glyphs / 16)
+  input.texHeight = input.tileHeight * math.floor(#input.glyphs / 16)
 
   -- convert to BMFont .fnt file
   local outputFile = io.open(outputFntPath, "w+")


### PR DESCRIPTION
Closes #4.

This PR addresses the early (and bad) assumption I made about Cap fonts always being 16 columns. As posed in #4, I considered adding Image Magick as another required CLI tool, but instead I opted to require modifications to .fnt files instead. The reasons being:
1. Another CLI tool dependency just to get image size didn't feel great.
2. We can add more keys later to further configure the conversion process.

This PR also fixes:
- Comment lines added by Caps not being ignored.
- Empty lines causing the conversion to fail.

