### PR TITLE
Implement better pushContext()/popContext()

### DIFF
--- a/header.lua
+++ b/header.lua
@@ -35,6 +35,8 @@ math.randomseed(os.time())
 local font = playdate.graphics.font.new("fonts/Phozon/Phozon")
 playdate.graphics.setFont(font)
 
+local updateCoroutine
+
 function love.draw()
   -- must be changed at start of frame when canvas is not active
   local newCanvasWidth, newCanvasHeight = playbit.graphics.getCanvasSize()
@@ -86,7 +88,14 @@ function love.draw()
   love.graphics.translate(playbit.graphics.drawOffset.x, playbit.graphics.drawOffset.y)
 
   -- main update
-  playdate.update()
+  if not updateCoroutine or coroutine.status(updateCoroutine) == "dead" then
+    updateCoroutine = coroutine.create(playdate.update)
+  end
+
+  local ok, err = coroutine.resume(updateCoroutine)
+  if not ok then
+    error(err)
+  end
 
   -- debug draw
   if playdate.debugDraw then

--- a/header.lua
+++ b/header.lua
@@ -68,7 +68,6 @@ function love.draw()
 
   -- render to canvas to allow 2x scaling
   love.graphics.setCanvas(playbit.graphics.canvas)
-  love.graphics.setShader(playbit.graphics.shader)
 
   --[[
     Love2d won't allow a canvas to be set outside of the draw function, so we need to do this on the first frame of draw.
@@ -111,12 +110,16 @@ function love.draw()
   love.graphics.setCanvas()
 
   -- clear shader so that canvas is rendered normally
-  love.graphics.setShader()
+  local shader = love.graphics.getShader()
+  love.graphics.setShader(playbit.graphics.shaders.final)
 
   -- draw canvas to screen
   local currentCanvasScale = playbit.graphics.getCanvasScale()
   local x, y = playbit.graphics.getCanvasPosition()
   love.graphics.draw(playbit.graphics.canvas, x, y, 0, currentCanvasScale, currentCanvasScale)
+
+  -- reset back the shader
+  love.graphics.setShader(shader)
 
   -- update emulated input
   playdate.updateInput()

--- a/header.lua
+++ b/header.lua
@@ -1,7 +1,7 @@
 !if LOVE2D then
 require("playbit.graphics")
 
---[[ since there is no CoreLibs/playdate, this file should always 
+--[[ since there is no CoreLibs/playdate, this file should always
 be included here so the methods are always available ]]--
 require("playdate.playdate")
 --[[ not really a way around including this one, but probably doesn't really
@@ -70,7 +70,7 @@ function love.draw()
   love.graphics.setCanvas(playbit.graphics.canvas)
   love.graphics.setShader(playbit.graphics.shader)
 
-  --[[ 
+  --[[
     Love2d won't allow a canvas to be set outside of the draw function, so we need to do this on the first frame of draw.
     Otherwise setting the bg color outside of playdate.update() won't be consistent with PD.
   --]]
@@ -113,17 +113,10 @@ function love.draw()
   -- clear shader so that canvas is rendered normally
   love.graphics.setShader()
 
-  -- always render pure white so its not tinted
-  local r, g, b = love.graphics.getColor()
-  love.graphics.setColor(1, 1, 1, 1)
-
   -- draw canvas to screen
   local currentCanvasScale = playbit.graphics.getCanvasScale()
   local x, y = playbit.graphics.getCanvasPosition()
   love.graphics.draw(playbit.graphics.canvas, x, y, 0, currentCanvasScale, currentCanvasScale)
-
-  -- reset back to set color
-  love.graphics.setColor(r, g, b, 1)
 
   -- update emulated input
   playdate.updateInput()

--- a/playbit/graphics.lua
+++ b/playbit/graphics.lua
@@ -10,6 +10,21 @@ module.COLOR_BLACK = { 49 / 255, 47 / 255, 40 / 255, 1 }
 
 module.colorWhite = module.COLOR_WHITE
 module.colorBlack = module.COLOR_BLACK
+
+module.shaders =
+{
+  final   = love.graphics.newShader("playbit/shaders/final.glsl"),
+  color   = love.graphics.newShader("playbit/shaders/color.glsl"),
+  pattern = love.graphics.newShader("playbit/shaders/pattern.glsl"),
+  image   = { }
+}
+
+local shader = love.filesystem.read("playbit/shaders/image.glsl")
+for i = 0, 9 do
+  local src = "#define DRAW_MODE " .. i .. "\n" .. shader
+  module.shaders.image[i] = love.graphics.newShader(src)
+end
+
 module.shader = love.graphics.newShader("playdate/shader")
 module.drawOffset = { x = 0, y = 0}
 module.drawColorIndex = 1

--- a/playbit/graphics.lua
+++ b/playbit/graphics.lua
@@ -153,20 +153,4 @@ function module.setDrawMode(mode)
     love.graphics.setShader(shader)
   end
 end
-
-function module.updateContext()
-  if #module.contextStack == 0 then
-    return
-  end
-
-  local activeContext = module.contextStack[#module.contextStack]
-
-  -- love2d doesn't allow calling newImageData() when canvas is active
-  love.graphics.setCanvas()
-  local imageData = activeContext._canvas:newImageData()
-  love.graphics.setCanvas(activeContext._canvas)
-
-  -- update image
-  activeContext.data:replacePixels(imageData)
-end
 !end

--- a/playbit/graphics.lua
+++ b/playbit/graphics.lua
@@ -39,7 +39,8 @@ module.contextStack = {}
 -- shared quad to reduce gc
 module.quad = love.graphics.newQuad(0, 0, 1, 1, 1, 1)
 module.lastClearColor = module.colorWhite
-module.drawPattern = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+module.drawPattern = nil
+module.lineWidth = 1
 
 local canvasScale = 1
 local canvasWidth = 400

--- a/playbit/graphics.lua
+++ b/playbit/graphics.lua
@@ -122,29 +122,10 @@ end
 ---@param white table An array of 4 values that correspond to RGBA that range from 0 to 1.
 ---@param black table An array of 4 values that correspond to RGBA that range from 0 to 1.
 function module.setColors(white, black)
-  if white == nil then
-    white = module.COLOR_WHITE
-  end
-  if black == nil then
-    black = module.COLOR_BLACK
-  end
-  
-  module.colorWhite = white
-  module.colorBlack = black
-  module.shader:send("white", white)
-  module.shader:send("black", black)
-
-  if module.backgroundColorIndex == 1 then
-    module.backgroundColor = module.colorWhite
-  else
-    module.backgroundColor = module.colorBlack
-  end
-
-  if module.drawColorIndex == 1 then
-    module.drawColor = module.colorWhite
-  else
-    module.drawColor = module.colorBlack
-  end
+  module.colorWhite = white or module.COLOR_WHITE
+  module.colorBlack = black or module.COLOR_BLACK
+  module.shaders.final:send("white", white)
+  module.shaders.final:send("black", black)
 end
 
 function module.updateContext()

--- a/playbit/graphics.lua
+++ b/playbit/graphics.lua
@@ -32,7 +32,8 @@ module.drawColor = module.colorWhite
 module.backgroundColorIndex = 0
 module.backgroundColor = module.colorBlack
 module.activeFont = {}
-module.drawMode = "copy"
+module.imageDrawMode = 0
+module.drawMode = nil
 module.canvas = love.graphics.newCanvas()
 module.contextStack = {}
 -- shared quad to reduce gc
@@ -126,6 +127,30 @@ function module.setColors(white, black)
   module.colorBlack = black or module.COLOR_BLACK
   module.shaders.final:send("white", white)
   module.shaders.final:send("black", black)
+end
+
+local function getShader(mode)
+  if mode == "line" then
+    return module.shaders.color
+
+  elseif mode == "fill" then
+    if module.drawPattern then
+      return module.shaders.pattern
+    else
+      return module.shaders.color
+    end
+
+  elseif mode == "image" then
+    return module.shaders.image[module.imageDrawMode]
+  end
+end
+
+function module.setDrawMode(mode)
+  if module.drawMode ~= mode then
+    module.drawMode = mode
+    local shader = getShader(mode)
+    love.graphics.setShader(shader)
+  end
 end
 
 function module.updateContext()

--- a/playbit/shaders/color.glsl
+++ b/playbit/shaders/color.glsl
@@ -1,0 +1,11 @@
+#pragma language glsl3
+
+extern vec4 drawColor;
+
+vec4 effect(vec4 color, Image tex, vec2 tex_coords, vec2 screen_coords)
+{
+    float outColor = drawColor.r;
+    float outAlpha = drawColor.a;
+
+    return vec4(outColor, outColor, outColor, outAlpha);
+}

--- a/playbit/shaders/final.glsl
+++ b/playbit/shaders/final.glsl
@@ -1,0 +1,15 @@
+#pragma language glsl3
+
+extern vec4 white = vec4(176.0f / 255.0f, 174.0f / 255.0f, 167.0f / 255.0f, 1);
+extern vec4 black = vec4( 49.0f / 255.0f,  47.0f / 255.0f,  40.0f / 255.0f, 1);
+
+vec4 effect(vec4 color, Image tex, vec2 tex_coords, vec2 screen_coords)
+{
+    vec4 inColor = Texel(tex, tex_coords) * color;
+
+    vec4 outColor;
+    outColor.rgb = mix(black.rgb, white.rgb, inColor.r);
+    outColor.a   = 1;
+
+    return outColor;
+}

--- a/playbit/shaders/image.glsl
+++ b/playbit/shaders/image.glsl
@@ -1,0 +1,49 @@
+#pragma language glsl3
+
+extern Image canvas;
+
+vec4 effect(vec4 color, Image tex, vec2 tex_coords, vec2 screen_coords)
+{
+    vec4  texColor   = Texel(tex, tex_coords);
+    float grayscale  = dot(texColor.rgb, vec3(0.2126, 0.7152, 0.0722));
+    float inColor    = step(0.5, grayscale);
+    float inAlpha    = step(0.5, texColor.a);
+
+#if DRAW_MODE == 1   // White Transparent
+    float outColor   = inColor;
+    float outAlpha   = inAlpha * (1.0 - inColor);
+
+#elif DRAW_MODE == 2 // Black Transparent
+    float outColor   = inColor;
+    float outAlpha   = inAlpha * inColor;
+
+#elif DRAW_MODE == 3 // Fill White
+    float outColor   = 1;
+    float outAlpha   = inAlpha;
+
+#elif DRAW_MODE == 4 // Fill Black
+    float outColor   = 0;
+    float outAlpha   = inAlpha;
+
+#elif DRAW_MODE == 5 // XOR
+    vec4 canvasColor = Texel(canvas, screen_coords / love_ScreenSize.xy);
+    float outColor   = abs(canvasColor.r - inColor);
+    float outAlpha   = inAlpha;
+
+#elif DRAW_MODE == 6 // NXOR
+    vec4 canvasColor = Texel(canvas, screen_coords / love_ScreenSize.xy);
+    float outColor   = 1.0 - abs(canvasColor.r - inColor);
+    float outAlpha   = inAlpha;
+
+#elif DRAW_MODE == 7 // Inverted
+    float outColor   = 1.0 - inColor;
+    float outAlpha   = inAlpha;
+
+#else                // Copy
+    float outColor   = inColor;
+    float outAlpha   = inAlpha;
+
+#endif
+
+    return vec4(outColor, outColor, outColor,  outAlpha);
+}

--- a/playbit/shaders/pattern.glsl
+++ b/playbit/shaders/pattern.glsl
@@ -1,0 +1,15 @@
+#pragma language glsl3
+
+extern float pattern[64];
+
+vec4 effect(vec4 color, Image tex, vec2 tex_coords, vec2 screen_coords)
+{
+    // Use mod() to get the position of the current pixel within the 8x8 pattern
+    int x = int(mod(screen_coords.x, 8.0));
+    int y = int(mod(screen_coords.y, 8.0));
+
+    float outColor = pattern[x + y * 8];
+    float outAlpha = 1;
+
+    return vec4(outColor, outColor, outColor, outAlpha);
+}

--- a/playbit/util.lua
+++ b/playbit/util.lua
@@ -24,3 +24,23 @@ function module.sign(a)
     return 0
   end
 end
+
+function module.clamp01(x)
+  if x <= 0 then
+    return 0
+  elseif x >= 1 then
+    return 1
+  else
+    return x
+  end
+end
+
+function module.clamp(x, min, max)
+  if x <= min then
+    return min
+  elseif x >= max then
+    return max
+  else
+    return x
+  end
+end

--- a/playdate/affineTransform.lua
+++ b/playdate/affineTransform.lua
@@ -209,6 +209,8 @@ function meta:transformPolygon(p)
     local j = i + 1
     pts[i], pts[j] = transform(self, pts[i], pts[j])
   end
+  -- reset cached length
+  p._length = nil
 end
 
 function meta:transformedPolygon(p)

--- a/playdate/affineTransform.lua
+++ b/playdate/affineTransform.lua
@@ -2,33 +2,66 @@ local module = {}
 playdate.geometry.affineTransform = module
 
 local meta = {}
-
 meta.__index = meta
+module.__index = meta
 
-meta.__mul = function(a, b)
-  error("[ERR] playdate.geometry.affineTransform.__mul is not yet implemented.")
+local function concat(a, b)
+  return
+    a.m11 * b.m11 + a.m21 * b.m12,
+    a.m12 * b.m11 + a.m22 * b.m12,
+    a.m11 * b.m21 + a.m21 * b.m22,
+    a.m12 * b.m21 + a.m22 * b.m22,
+    a.tx  * b.m11 + a.ty  * b.m12 + b.tx,
+    a.tx  * b.m21 + a.ty  * b.m22 + b.ty
 end
 
-module.__index = meta
+
+local function transform(t, x, y)
+  return
+    x * t.m11 + y * t.m12 + t.tx,
+    x * t.m21 + y * t.m22 + t.ty
+end
+
+local function translation(dx, dy)
+  return module.new(1, 0, 0, 1, dx, dy)
+end
+
+local function scaling(sx, sy)
+  sy = sy or sx
+  return module.new(sx, 0, 0, sy, 0, 0)
+end
+
+local function rotation(angle)
+  angle = math.rad(angle)
+  local c = math.cos(angle)
+  local s = math.sin(angle)
+  return module.new(c, -s, s, c, 0, 0)
+end
+
+local function rotationAround(angle, px, py)
+  local rad = math.rad(angle)
+  local c = math.cos(rad)
+  local s = math.sin(rad)
+  local tx = px - px * c + py * s
+  local ty = py - px * s - py * c
+  return module.new(c, -s, s, c, tx, ty)
+end
+
+local function skewing(sx, sy)
+  local rx = math.tan(math.rad(sx))
+  local ry = math.tan(math.rad(sy))
+  return module.new(1, rx, ry, 1, 0, 0)
+end
 
 function module.new(m11, m12, m21, m22, tx, ty)
   local o = {}
 
-  if m11 then
-    o.m11 = m11
-    o.m12 = m12
-    o.m21 = m21
-    o.m22 = m22
-    o.tx  = tx
-    o.ty  = ty
-  else
-    o.m11 = 1
-    o.m12 = 0
-    o.m21 = 0
-    o.m22 = 1
-    o.tx  = 0
-    o.ty  = 0
-  end
+  o.m11 = m11 or 1
+  o.m12 = m12 or 0
+  o.m21 = m21 or 0
+  o.m22 = m22 or 1
+  o.tx  = tx  or 0
+  o.ty  = ty  or 0
 
   setmetatable(o, meta)
   return o
@@ -43,7 +76,27 @@ function meta:unpack()
 end
 
 function meta:invert()
-  error("[ERR] playdate.geometry.affineTransform:invert() is not yet implemented.")
+  local a, b   = self.m11, self.m12
+  local c, d   = self.m21, self.m22
+  local tx, ty = self.tx,  self.ty
+
+  local det = a * d - b * c
+  local invDet = 1 / det
+
+  local im11 = d * invDet
+  local im12 = -b * invDet
+  local im21 = -c * invDet
+  local im22 = a * invDet
+
+  local itx = -(im11 * tx + im12 * ty)
+  local ity = -(im21 * tx + im22 * ty)
+
+  self.m11 = im11
+  self.m12 = im12
+  self.m21 = im21
+  self.m22 = im22
+  self.tx  = itx
+  self.ty  = ity
 end
 
 function meta:reset()
@@ -55,74 +108,89 @@ function meta:reset()
   self.ty  = 0
 end
 
-function meta:concat(af)
-  local m11 = self.m11 * af.m11 + self.m12 * af.m21
-  local m12 = self.m11 * af.m12 + self.m12 * af.m22
-
-  local m21 = self.m21 * af.m11 + self.m22 * af.m21
-  local m22 = self.m21 * af.m12 + self.m22 * af.m22
-
-  local tx  = self.m11 * af.tx  + self.m12 * af.ty + self.tx
-  local ty  = self.m21 * af.tx  + self.m22 * af.ty + self.ty
-
-  return module.new(m11, m12, m21, m22, tx, ty)
+function meta:concat(b)
+  self.m11, self.m12, self.m21, self.m22, self.tx, self.ty = concat(self, b)
 end
 
 function meta:translate(dx, dy)
-  error("[ERR] playdate.geometry.affineTransform:translate() is not yet implemented.")
+  local t = translation(dx, dy)
+  self:concat(t)
 end
 
 function meta:translatedBy(dx, dy)
-  error("[ERR] playdate.geometry.affineTransform:translatedBy() is not yet implemented.")
+  local t = self:copy()
+  t:translate(dx, dy)
+  return t
 end
 
 function meta:scale(sx, sy)
-  error("[ERR] playdate.geometry.affineTransform:scale() is not yet implemented.")
+  local t = scaling(sx, sy)
+  self:concat(t)
 end
 
 function meta:scaledBy(sx, sy)
-  error("[ERR] playdate.geometry.affineTransform:scaledBy() is not yet implemented.")
+  local t = self:copy()
+  t:scale(sx, sy)
+  return t
 end
 
-function meta:rotate(angle, pointOrX, y)
-  error("[ERR] playdate.geometry.affineTransform:rotate() is not yet implemented.")
+function meta:rotate(angle, x, y)
+  local t
+
+  if x then
+    if y then
+      t = rotationAround(angle, x, y)
+    else
+      local pt = x
+      t = rotationAround(angle, pt.x, pt.y)
+    end
+  else
+    t = rotation(angle)
+  end
+
+  self:concat(t)
 end
 
-function meta:rotateBy(angle, pointOrX, y)
-  error("[ERR] playdate.geometry.affineTransform:rotateBy() is not yet implemented.")
+function meta:rotatedBy(angle, pointOrX, y)
+  local t = self:copy()
+  t:rotate(angle, pointOrX, y)
+  return t
 end
 
 function meta:skew(sx, sy)
-  error("[ERR] playdate.geometry.affineTransform:skew() is not yet implemented.")
+  local t = skewing(sx, sy)
+  self:concat(t)
 end
 
 function meta:skewedBy(sx, sy)
-  error("[ERR] playdate.geometry.affineTransform:skewedBy() is not yet implemented.")
-end
-
-function meta:transformPoint(p)
-  local nx, ny = self:transformXY(p.x, p.y)
-  p.x = nx
-  p.y = ny
-end
-
-function meta:transformedPoint(p)
-  local nx, ny = self:transformXY(p.x, p.y)
-  return playdate.geometry.point.new(nx, ny)
+  local t = self:copy()
+  t:skew(sx, sy)
+  return t
 end
 
 function meta:transformXY(x, y)
-  local nx = x * self.m11 + y * self.m12 + self.tx
-  local ny = x * self.m21 + y * self.m22 + self.ty
-  return nx, ny
+  return transform(self, x, y)
+end
+
+function meta:transformPoint(p)
+  p.x, p.y = transform(self, p.x, p.y)
+end
+
+function meta:transformedPoint(p)
+  local c = p:copy()
+  self:transformPoint(c)
+  return c
 end
 
 function meta:transformLineSegment(ls)
-  error("[ERR] playdate.geometry.affineTransform:transformLineSegment() is not yet implemented.")
+  ls.x1, ls.y1 = transform(self, ls.x1, ls.y1)
+  ls.x2, ls.y2 = transform(self, ls.x2, ls.y2)
 end
 
 function meta:transformedLineSegment(ls)
-  error("[ERR] playdate.geometry.affineTransform:transformedLineSegment() is not yet implemented.")
+  local c = ls:copy()
+  self:transformLineSegment(c)
+  return c
 end
 
 function meta:transformAABB(r)
@@ -130,13 +198,41 @@ function meta:transformAABB(r)
 end
 
 function meta:transformedAABB(r)
-  error("[ERR] playdate.geometry.affineTransform:transformedAABB() is not yet implemented.")
+  local c = r:copy()
+  self:transformAABB(c)
+  return c
 end
 
 function meta:transformPolygon(p)
-  error("[ERR] playdate.geometry.affineTransform:transformPolygon() is not yet implemented.")
+  local pts = p._points
+  for i = 1, #pts, 2 do
+    local j = i + 1
+    pts[i], pts[j] = transform(self, pts[i], pts[j])
+  end
 end
 
 function meta:transformedPolygon(p)
-  error("[ERR] playdate.geometry.affineTransform:transformedPolygon() is not yet implemented.")
+  local c = p:copy()
+  self:transformPolygon(c)
+  return c
+end
+
+meta.__mul = function(a, b)
+  if b._type == "point" then
+    local x, y = transform(a, b.x, b.y)
+    return playdate.geometry.point.new(x, y)
+
+  elseif b._type == "vector2D" then
+    local dx, dy = transform(a, b.dx, b.dy)
+    return playdate.geometry.vector2D.new(dx, dy)
+
+  else
+    local m11, m12, m21, m22, tx, ty = concat(a, b)
+    return module.new(m11, m12, m21, m22, tx, ty)
+  end
+end
+
+meta.__tostring = function(t)
+    return string.format("(m11=%s, m12=%s, m21=%s, m22=%s, tx=%s, ty=%s)",
+      t.m11, t.m12, t.m21, t.m22, t.tx, t.ty)
 end

--- a/playdate/affineTransform.lua
+++ b/playdate/affineTransform.lua
@@ -1,0 +1,142 @@
+local module = {}
+playdate.geometry.affineTransform = module
+
+local meta = {}
+
+meta.__index = meta
+
+meta.__mul = function(a, b)
+  error("[ERR] playdate.geometry.affineTransform.__mul is not yet implemented.")
+end
+
+module.__index = meta
+
+function module.new(m11, m12, m21, m22, tx, ty)
+  local o = {}
+
+  if m11 then
+    o.m11 = m11
+    o.m12 = m12
+    o.m21 = m21
+    o.m22 = m22
+    o.tx  = tx
+    o.ty  = ty
+  else
+    o.m11 = 1
+    o.m12 = 0
+    o.m21 = 0
+    o.m22 = 1
+    o.tx  = 0
+    o.ty  = 0
+  end
+
+  setmetatable(o, meta)
+  return o
+end
+
+function meta:copy()
+  return module.new(self.m11, self.m12, self.m21, self.m22, self.tx, self.ty)
+end
+
+function meta:unpack()
+  return self.m11, self.m12, self.m21, self.m22, self.tx, self.ty
+end
+
+function meta:invert()
+  error("[ERR] playdate.geometry.affineTransform:invert() is not yet implemented.")
+end
+
+function meta:reset()
+  self.m11 = 1
+  self.m12 = 0
+  self.m21 = 0
+  self.m22 = 1
+  self.tx  = 0
+  self.ty  = 0
+end
+
+function meta:concat(af)
+  local m11 = self.m11 * af.m11 + self.m12 * af.m21
+  local m12 = self.m11 * af.m12 + self.m12 * af.m22
+
+  local m21 = self.m21 * af.m11 + self.m22 * af.m21
+  local m22 = self.m21 * af.m12 + self.m22 * af.m22
+
+  local tx  = self.m11 * af.tx  + self.m12 * af.ty + self.tx
+  local ty  = self.m21 * af.tx  + self.m22 * af.ty + self.ty
+
+  return module.new(m11, m12, m21, m22, tx, ty)
+end
+
+function meta:translate(dx, dy)
+  error("[ERR] playdate.geometry.affineTransform:translate() is not yet implemented.")
+end
+
+function meta:translatedBy(dx, dy)
+  error("[ERR] playdate.geometry.affineTransform:translatedBy() is not yet implemented.")
+end
+
+function meta:scale(sx, sy)
+  error("[ERR] playdate.geometry.affineTransform:scale() is not yet implemented.")
+end
+
+function meta:scaledBy(sx, sy)
+  error("[ERR] playdate.geometry.affineTransform:scaledBy() is not yet implemented.")
+end
+
+function meta:rotate(angle, pointOrX, y)
+  error("[ERR] playdate.geometry.affineTransform:rotate() is not yet implemented.")
+end
+
+function meta:rotateBy(angle, pointOrX, y)
+  error("[ERR] playdate.geometry.affineTransform:rotateBy() is not yet implemented.")
+end
+
+function meta:skew(sx, sy)
+  error("[ERR] playdate.geometry.affineTransform:skew() is not yet implemented.")
+end
+
+function meta:skewedBy(sx, sy)
+  error("[ERR] playdate.geometry.affineTransform:skewedBy() is not yet implemented.")
+end
+
+function meta:transformPoint(p)
+  local nx, ny = self:transformXY(p.x, p.y)
+  p.x = nx
+  p.y = ny
+end
+
+function meta:transformedPoint(p)
+  local nx, ny = self:transformXY(p.x, p.y)
+  return playdate.geometry.point.new(nx, ny)
+end
+
+function meta:transformXY(x, y)
+  local nx = x * self.m11 + y * self.m12 + self.tx
+  local ny = x * self.m21 + y * self.m22 + self.ty
+  return nx, ny
+end
+
+function meta:transformLineSegment(ls)
+  error("[ERR] playdate.geometry.affineTransform:transformLineSegment() is not yet implemented.")
+end
+
+function meta:transformedLineSegment(ls)
+  error("[ERR] playdate.geometry.affineTransform:transformedLineSegment() is not yet implemented.")
+end
+
+function meta:transformAABB(r)
+  error("[ERR] playdate.geometry.affineTransform:transformAABB() is not yet implemented.")
+end
+
+function meta:transformedAABB(r)
+  error("[ERR] playdate.geometry.affineTransform:transformedAABB() is not yet implemented.")
+end
+
+function meta:transformPolygon(p)
+  error("[ERR] playdate.geometry.affineTransform:transformPolygon() is not yet implemented.")
+end
+
+function meta:transformedPolygon(p)
+  error("[ERR] playdate.geometry.affineTransform:transformedPolygon() is not yet implemented.")
+end

--- a/playdate/animator.lua
+++ b/playdate/animator.lua
@@ -1,6 +1,6 @@
 -- docs: https://sdk.play.date/2.6.2/Inside%20Playdate.html#C-graphics.animator
 
-require("easing")
+require("playdate.easing")
 
 playdate.graphics = playdate.graphics or {}
 
@@ -11,33 +11,281 @@ local meta = {}
 meta.__index = meta
 module.__index = meta
 
--- note: this function has 5 overloaded definitions as of 2.6.2. 
+local function normalizeTime(anim, t)
+  t = t - anim._startTimeOffset
+
+  if t < 0 then
+    return 0, false
+  end
+
+  local dur = anim._duration
+  if anim.reverses then
+    dur = dur * 2
+  end
+
+  local repeats = math.floor(t / dur)
+
+  t = t % dur
+
+  if t > anim._duration then
+    t = 2 * anim._duration - t
+  end
+
+  if not anim.repeats and anim.repeatCount >= 0 and repeats > anim.repeatCount then
+    if anim.reverses then
+      return 0, true
+    else
+      return anim._duration, true
+    end
+  end
+
+  return t, false
+end
+
+local function updateAnimator(anim)
+  if not anim._ended then
+    local t = playdate.getCurrentTimeMilliseconds() - anim._startTime
+    anim._currentTime, anim._ended = normalizeTime(anim, t)
+  end
+end
+
+local function getValueForNumbers(anim, time)
+  return anim._easingFunction(time, anim._startValue, anim._endValue - anim._startValue, anim._duration)
+end
+
+local function getValueForPoints(anim, time)
+  local startValue = anim._startValue
+  local endValue = anim._endValue
+  local x = anim._easingFunction(time, startValue.x, endValue.x - startValue.x, anim._duration)
+  local y = anim._easingFunction(time, startValue.y, endValue.y - startValue.y, anim._duration)
+  return playdate.geometry.point.new(x, y)
+end
+
+local function getValueForLineSegment(anim, time)
+  local lineSegment = anim._lineSegment
+  local dist = anim._easingFunction(time, 0, lineSegment:length(), anim._duration, anim.s or anim.easingAmplitude,
+    anim.easingPeriod)
+  return lineSegment:pointOnLine(dist, true)
+end
+
+local function getValueForArc(anim, time)
+  local arc = anim._arc
+  local dist = anim._easingFunction(time, 0, arc:length(), anim._duration, anim.s or anim.easingAmplitude,
+    anim.easingPeriod)
+  return arc:pointOnArc(dist, true)
+end
+
+local function getValueForPolygon(anim, time)
+  local polygon = anim._polygon
+  local dist = anim._easingFunction(time, 0, polygon:length(), anim._duration, anim.s or anim.easingAmplitude,
+    anim.easingPeriod)
+  return polygon:pointOnPolygon(dist, true)
+end
+
+local function getValueForPart(part, dist)
+  if part._type == "lineSegment" then
+    return part:pointOnLine(dist, true)
+  elseif part._type == "arc" then
+    return part:pointOnArc(dist, true)
+  elseif part._type == "polygon" then
+    return part:pointOnPolygon(dist, true)
+  end
+end
+
+local function getValueForParts(anim, time)
+  local parts = anim._parts
+  local lengths = anim._lengths
+  local dist = anim._easingFunction(time, 0, anim._totalLength, anim._duration, anim.s or anim.easingAmplitude, anim.easingPeriod)
+
+  local i = 1
+  while i < #parts and dist > lengths[i] do
+    i = i + 1
+  end
+
+  local part = parts[i]
+  local dist = dist - (lengths[i - 1] or 0)
+
+  return getValueForPart(part, dist)
+end
+
+local function getValueForPartsWithDurations(anim, time)
+  local parts = anim._parts
+  local lengths = anim._lengths
+  local durations = anim._durations
+
+  local i = 1
+  while time > durations[i] do
+    time = time - durations[i]
+    i = i + 1
+  end
+
+  local part = parts[i]
+  local easingFunction = anim._easingFunctions[i]
+  local dist = easingFunction(time, 0, part:length(), durations[i], anim.s or anim.easingAmplitude, anim.easingPeriod)
+
+  return getValueForPart(part, dist)
+end
+
+
+local function newAnimator(duration, easingFunction, startTimeOffset)
+  local anim = setmetatable({}, meta)
+  anim._duration = duration
+  anim._startTime = playdate.getCurrentTimeMilliseconds()
+  anim._startTimeOffset = startTimeOffset or 0
+  anim._easingFunction = easingFunction or playdate.easingFunctions.linear
+
+  anim.repeatCount = 0
+  anim.reverses = false
+  anim.easingAmplitude = nil
+  anim.easingPeriod = nil
+  return anim
+end
+
+local function newAnimatorFromNumber(duration, startValue, endValue, easingFunction, startTimeOffset)
+  local anim = newAnimator(duration, easingFunction, startTimeOffset)
+  anim._startValue = startValue
+  anim._endValue = endValue
+  anim._getValue = getValueForNumbers
+  return anim
+end
+
+local function newAnimatorFromPoints(duration, startValue, endValue, easingFunction, startTimeOffset)
+  local anim = newAnimator(duration, easingFunction, startTimeOffset)
+  anim._startValue = startValue
+  anim._endValue = endValue
+  anim._getValue = getValueForNumbers
+  return anim
+end
+
+local function newAnimatorFromLineSegment(duration, lineSegment, easingFunction, startTimeOffset)
+  local anim = newAnimator(duration, easingFunction, startTimeOffset)
+  anim._lineSegment = lineSegment
+  anim._getValue = getValueForLineSegment
+  return anim
+end
+
+local function newAnimatorFromArc(duration, arc, easingFunction, startTimeOffset)
+  local anim = newAnimator(duration, easingFunction, startTimeOffset)
+  anim._arc = arc
+  anim._getValue = getValueForArc
+  return anim
+end
+
+local function newAnimatorFromPolygon(duration, polygon, easingFunction, startTimeOffset)
+  local anim = newAnimator(duration, easingFunction, startTimeOffset)
+  anim._polygon = polygon
+  anim._getValue = getValueForPolygon
+  return anim
+end
+
+local function calculatePartsLength(parts)
+  local totalLength = 0
+  local lengths = {}
+  for i = 1, #parts do
+    local part = parts[i]
+    totalLength = totalLength + part:length()
+    lengths[i] = totalLength
+  end
+  return lengths, totalLength
+end
+
+local function newAnimatorFromPartsWithDurations(durations, parts, easingFunctions, startTimeOffset)
+  assert(#durations == #parts)
+  assert(#easingFunctions == #parts)
+
+  local totalDuration = 0
+  for i = 1, #durations do
+    totalDuration = totalDuration + durations[i]
+  end
+
+  local anim = newAnimator(totalDuration, nil, startTimeOffset)
+  anim._durations = durations
+  anim._easingFunctions = easingFunctions
+  anim._parts = parts
+  anim._getValue = getValueForPartsWithDurations
+  anim._lengths, anim._totalLength = calculatePartsLength(parts)
+
+  return anim
+end
+
+local function newAnimatorFromParts(duration, parts, easingFunction, startTimeOffset)
+  local anim = newAnimator(duration, easingFunction, startTimeOffset)
+  anim._parts = parts
+  anim._getValue = getValueForParts
+  anim._lengths, anim._totalLength = calculatePartsLength(parts)
+  return anim
+end
+
+-- note: this function has 5 overloaded definitions as of 2.6.2.
 -- the parameters will first need to be interpreted, then passed off to an appropriate local function for processing.
 function module.new(a, b, c, d, e)
-    error("[ERR] playdate.graphics.animator.new() is not yet implemented.")
+  if type(b) == "table" then
+    if b._type then
+      if b._type == "point" then
+        return newAnimatorFromPoints(a, b, c, d, e)
+      elseif b._type == "lineSegment" then
+        return newAnimatorFromLineSegment(a, b, c, d)
+      elseif b._type == "arc" then
+        return newAnimatorFromArc(a, b, c, d)
+      elseif b._type == "polygon" then
+        return newAnimatorFromPolygon(a, b, c, d)
+      end
+    else
+      if type(a) == "number" then
+        return newAnimatorFromParts(a, b, c, d)
+      else
+        return newAnimatorFromPartsWithDurations(a, b, c, d)
+      end
+    end
+  else
+    return newAnimatorFromNumber(a, b, c, d, e)
+  end
 end
 
 function meta:currentValue()
-    error("[ERR] playdate.graphics.animator:currentValue() is not yet implemented.")
+  updateAnimator(self)
+  return self:_getValue(self._currentTime)
 end
 
 function meta:valueAtTime(time)
-    error("[ERR] playdate.graphics.animator:valueAtTime() is not yet implemented.")
+  time = normalizeTime(self, time)
+  return self:_getValue(time)
 end
 
 function meta:progress()
-    error("[ERR] playdate.graphics.animator:progress() is not yet implemented.")
+  updateAnimator(self)
+
+  if self.repeats or self.repeatCount < 0 then
+    return nil
+  end
+
+  if self._ended then
+    return 1
+  end
+
+  local dur = self._duration
+  if self.reverses then
+    dur = dur * 2
+  end
+
+  dur = dur + self.repeatCount * dur
+
+  local t = playdate.getCurrentTimeMilliseconds() - self._startTime
+
+  return playbit.util.clamp01(t / dur)
 end
 
 function meta:reset(duration)
-    error("[ERR] playdate.graphics.animator:reset() is not yet implemented.")
+  self._duration = duration or self._duration
+  self._startTime = playdate.getCurrentTimeMilliseconds()
+  self._currentTime = 0
+  self._ended = false
 end
 
 function meta:ended()
-    error("[ERR] playdate.graphics.animator:ended() is not yet implemented.")
+  updateAnimator(self)
+  return self._ended
 end
 
 module.easingAmplitude = nil
 module.easingPeriod = nil
-module.repeatCount = nil
-module.reverses = nil

--- a/playdate/arc.lua
+++ b/playdate/arc.lua
@@ -72,8 +72,8 @@ function meta:pointOnArc(distance, extend)
   end
 
   -- on PD angle 0 is Up.
-  local x =  self.radius * math.sin(angleRad)
-  local y = -self.radius * math.cos(angleRad)
+  local x = self.x + self.radius * math.sin(angleRad)
+  local y = self.y - self.radius * math.cos(angleRad)
 
   return playdate.geometry.point.new(x, y)
 end

--- a/playdate/arc.lua
+++ b/playdate/arc.lua
@@ -1,0 +1,79 @@
+require("playbit.util")
+
+local module = {}
+playdate.geometry.arc = module
+
+local meta = {}
+meta.__index = meta
+module.__index = meta
+
+function module.new(x, y, radius, startAngle, endAngle, direction)
+  local o = {}
+
+  o._type = "arc"
+  o.x = x
+  o.y = y
+  o.radius = radius
+  o.startAngle = startAngle
+  o.endAngle = endAngle
+
+  if direction == nil then
+    o.clockwise = o.endAngle >= o.startAngle
+  else
+    o.clockwise = direction
+  end
+
+  setmetatable(o, meta)
+  return o
+end
+
+function meta:copy()
+  return module.new(self.x, self.y, self.radius, self.startAngle, self.endAngle, self.clockwise)
+end
+
+function meta:length()
+  local angle = self.endAngle - self.startAngle
+
+  if not self.clockwise then
+    angle = -angle
+  end
+
+  -- this is not correct but this is how PD works,
+  -- confirmed by experiments
+  if angle < 0 then
+    angle = math.abs(angle + 360)
+  end
+
+  return self.radius * math.rad(angle)
+end
+
+function meta:isClockwise()
+  return self.clockwise
+end
+
+function meta:setIsClockwise(flag)
+  self.clockwise = flag
+end
+
+function meta:pointOnArc(distance, extend)
+  if not extend then
+    local length = self:length()
+    distance = playbit.util.clamp(distance, 0, length)
+  end
+
+  local startAngleRad = math.rad(self.startAngle)
+  local deltaAngleRad = distance / self.radius
+  local angleRad
+
+  if self.clockwise then
+    angleRad = startAngleRad + deltaAngleRad
+  else
+    angleRad = startAngleRad - deltaAngleRad
+  end
+
+  -- on PD angle 0 is Up.
+  local x =  self.radius * math.sin(angleRad)
+  local y = -self.radius * math.cos(angleRad)
+
+  return playdate.geometry.point.new(x, y)
+end

--- a/playdate/font.lua
+++ b/playdate/font.lua
@@ -83,7 +83,6 @@ function meta:drawText(str, x, y, width, height, leadingAdjustment, wrapMode, al
   love.graphics.setFont(self.data)
   love.graphics.print(str, x, y)
   love.graphics.setFont(currentFont)
-  playbit.graphics.updateContext()
 end
 
 -- 0=left 1=right 2=center
@@ -104,7 +103,6 @@ function meta:drawTextAligned(str, x, y, alignment, leadingAdjustment)
   love.graphics.setFont(self.data)
   love.graphics.print(str, x, y)
   love.graphics.setFont(currentFont)
-  playbit.graphics.updateContext()
 end
 
 function meta:_drawTextInRect(text, x, y, width, height, leadingAdjustment, truncationString, textAlignment)

--- a/playdate/font.lua
+++ b/playdate/font.lua
@@ -39,7 +39,7 @@ function module.getSystemFont(variant)
 end
 
 function meta:getTextWidth(str)
-  --[[ 
+  --[[
     NOTE: width returned will not be the same as on Playdate
     if a tracking value is set in the font (.fnt)
     https://github.com/GamesRightMeow/playbit/issues/12
@@ -79,6 +79,7 @@ function meta:drawText(str, x, y, width, height, leadingAdjustment, wrapMode, al
   @@ASSERT(wrapMode == nil, "[ERR] Parameter wrapMode is not yet implemented.")
   @@ASSERT(alignment == nil, "[ERR] Parameter alignment is not yet implemented.")
   local currentFont = love.graphics.getFont()
+  playbit.graphics.setDrawMode("image")
   love.graphics.setFont(self.data)
   love.graphics.print(str, x, y)
   love.graphics.setFont(currentFont)
@@ -94,11 +95,12 @@ function meta:drawTextAligned(str, x, y, alignment, leadingAdjustment)
     x = x - width
   elseif alignment == 2 then
     -- center
-    x = x - width * 0.5  
+    x = x - width * 0.5
   end
   -- left, draw normally
-  
+
   local currentFont = love.graphics.getFont()
+  playbit.graphics.setDrawMode("image")
   love.graphics.setFont(self.data)
   love.graphics.print(str, x, y)
   love.graphics.setFont(currentFont)
@@ -107,9 +109,9 @@ end
 
 function meta:_drawTextInRect(text, x, y, width, height, leadingAdjustment, truncationString, textAlignment)
   y = y - 1
-  
+
   local lineHeight = self:getHeight() + self:getLeading() + leadingAdjustment
-  
+
   if lineHeight > height then
     -- even one line won't fit
     return 0, 0, false
@@ -131,7 +133,7 @@ function meta:_drawTextInRect(text, x, y, width, height, leadingAdjustment, trun
     -- trimm trailing space
     line = string.sub(line, 1, #line - 1)
 
-    if lineHeight * (lineCount + 1) > height 
+    if lineHeight * (lineCount + 1) > height
     or lineHeight * (lineCount + 2) > height then
       -- this line or the next line surpasses specified max height
       line = line..truncationString
@@ -169,6 +171,6 @@ function meta:_drawTextInRect(text, x, y, width, height, leadingAdjustment, trun
       largestLineWidth = lineWidth
     end
   end
-  
+
   return largestLineWidth, (lineHeight * lineCount) - leadingAdjustment, truncated
 end

--- a/playdate/geometry.lua
+++ b/playdate/geometry.lua
@@ -1,0 +1,28 @@
+local module = {}
+playdate.geometry = module
+
+require("playdate.affineTransform")
+require("playdate.arc")
+require("playdate.lineSegment")
+require("playdate.point")
+require("playdate.polygon")
+require("playdate.rect")
+require("playdate.size")
+require("playdate.vector2D")
+
+module.kUnflipped = 0
+module.kFlippedX = 1
+module.kFlippedY = 2
+module.kFlippedXY = 3
+
+function module.squaredDistanceToPoint(x1, y1, x2, y2)
+  local dx = x2 - x1
+  local dy = y2 - y1
+  return dx * dx + dy * dy
+end
+
+function module.distanceToPoint(x1, y1, x2, y2)
+  local dx = x2 - x1
+  local dy = y2 - y1
+  return math.sqrt(dx * dx + dy * dy)
+end

--- a/playdate/graphics.lua
+++ b/playdate/graphics.lua
@@ -222,7 +222,7 @@ end
 function module.drawLine(x1, y1, x2, y2)
   playbit.graphics.shader:send("mode", 8)
 
-  if type(x) ~= "number" then
+  if type(x1) ~= "number" then
     local ls = x1
     x1, y1, x2, y2 = ls:unpack()
   end
@@ -236,7 +236,7 @@ end
 function module.drawPolygon(x1, y1, x2, y2, ...)
   playbit.graphics.shader:send("mode", 8)
 
-  if type(x) ~= "number" then
+  if type(x1) ~= "number" then
     local poly = x1
     if poly:isClosed() then
       love.graphics.polygon("line", unpack(poly._points))

--- a/playdate/graphics.lua
+++ b/playdate/graphics.lua
@@ -131,7 +131,6 @@ function module.clear(color)
     love.graphics.clear(c[1], c[2], c[3], c[4])
     playbit.graphics.lastClearColor = c
   end
-  playbit.graphics.updateContext()
 end
 
 -- "copy", "inverted", "XOR", "NXOR", "whiteTransparent", "blackTransparent", "fillWhite", or "fillBlack".
@@ -158,7 +157,6 @@ function module.drawCircleAtPoint(x, y, radius)
   end
 
   love.graphics.circle("line", x, y, radius)
-  playbit.graphics.updateContext()
 end
 
 function module.fillCircleAtPoint(x, y, radius)
@@ -171,7 +169,6 @@ function module.fillCircleAtPoint(x, y, radius)
   end
 
   love.graphics.circle("fill", x, y, radius)
-  playbit.graphics.updateContext()
 end
 
 function module.drawEllipseInRect(x, y, width, height, startAngle, endAngle)
@@ -226,7 +223,6 @@ function module.drawRect(x, y, width, height)
   end
 
   love.graphics.rectangle("line", x, y, width, height)
-  playbit.graphics.updateContext()
 end
 
 function module.fillRect(x, y, width, height)
@@ -238,7 +234,6 @@ function module.fillRect(x, y, width, height)
   end
 
   love.graphics.rectangle("fill", x, y, width, height)
-  playbit.graphics.updateContext()
 end
 
 function module.drawRoundRect(x, y, width, height, radius)
@@ -246,7 +241,6 @@ function module.drawRoundRect(x, y, width, height, radius)
   -- playbit.graphics.setDrawMode("line")
 
   -- love.graphics.rectangle("line", x, y, width, height, radius, radius, 0)
-  -- playbit.graphics.updateContext()
   error("[ERR] playdate.graphics.drawRoundRect() is not yet implemented.")
 end
 
@@ -255,7 +249,6 @@ function module.fillRoundRect(x, y, width, height, radius)
   --   playbit.graphics.setDrawMode("fill")
 
   -- love.graphics.rectangle("fill", x, y, width, height, radius, radius, 0)
-  -- playbit.graphics.updateContext()
   error("[ERR] playdate.graphics.fillRoundRect() is not yet implemented.")
 end
 
@@ -268,7 +261,6 @@ function module.drawLine(x1, y1, x2, y2)
   end
 
   love.graphics.line(x1, y1, x2, y2)
-  playbit.graphics.updateContext()
 end
 
 function module.drawPolygon(x1, y1, x2, y2, ...)
@@ -284,8 +276,6 @@ function module.drawPolygon(x1, y1, x2, y2, ...)
   else
     love.graphics.polygon("line", x1, y1, x2, y2, ...)
   end
-
-  playbit.graphics.updateContext()
 end
 
 function module.drawArc(x, y, radius, startAngle, endAngle)
@@ -315,15 +305,12 @@ function module.drawArc(x, y, radius, startAngle, endAngle)
   playbit.graphics.setDrawMode("line")
 
   love.graphics.arc("line", "open", x, y, radius, math.rad(startAngle), math.rad(endAngle), 32)
-
-  playbit.graphics.updateContext()
 end
 
 function module.drawPixel(x, y)
   playbit.graphics.setDrawMode("line")
 
   love.graphics.points(x, y)
-  playbit.graphics.updateContext()
 end
 
 function module.perlin(x, y, z, rep, octaves, persistence)
@@ -462,7 +449,6 @@ function module.drawText(text, x, y, width, height, fontFamily, leadingAdjustmen
   @@ASSERT(text ~= nil, "Text is nil")
   local font = playbit.graphics.activeFont
   font:drawText(text, x, y, fontFamily, leadingAdjustment)
-  playbit.graphics.updateContext()
 end
 
 -- TODO: handle the overloaded signature (key, rect, language, leadingAdjustment)

--- a/playdate/graphics.lua
+++ b/playdate/graphics.lua
@@ -132,6 +132,12 @@ end
 function module.drawCircleAtPoint(x, y, radius)
   playbit.graphics.shader:send("mode", 8)
 
+  if type(x) ~= "number" then
+    local pt = x
+    radius = y
+    x, y = pt.x, pt.y
+  end
+
   love.graphics.circle("line", x, y, radius)
   playbit.graphics.updateContext()
 
@@ -141,6 +147,12 @@ end
 function module.fillCircleAtPoint(x, y, radius)
   playbit.graphics.shader:send("mode", 8)
 
+  if type(x) ~= "number" then
+    local pt = x
+    radius = y
+    x, y = pt.x, pt.y
+  end
+
   love.graphics.circle("fill", x, y, radius)
   playbit.graphics.updateContext()
 
@@ -148,6 +160,8 @@ function module.fillCircleAtPoint(x, y, radius)
 end
 
 function module.setLineWidth(width)
+  -- PD examples use line width 0 but love2d does not support it.
+  if width < 1 then width = 1 end
   love.graphics.setLineWidth(width)
 end
 
@@ -158,6 +172,11 @@ end
 function module.drawRect(x, y, width, height)
   playbit.graphics.shader:send("mode", 8)
 
+  if type(x) ~= "number" then
+    local r = x
+    x, y, width, height = r:unpack()
+  end
+
   love.graphics.rectangle("line", x, y, width, height)
   playbit.graphics.updateContext()
 
@@ -166,6 +185,11 @@ end
 
 function module.fillRect(x, y, width, height)
   playbit.graphics.shader:send("mode", 8)
+
+  if type(x) ~= "number" then
+    local r = x
+    x, y, width, height = r:unpack()
+  end
 
   love.graphics.rectangle("fill", x, y, width, height)
   playbit.graphics.updateContext()
@@ -198,9 +222,32 @@ end
 function module.drawLine(x1, y1, x2, y2)
   playbit.graphics.shader:send("mode", 8)
 
+  if type(x) ~= "number" then
+    local ls = x1
+    x1, y1, x2, y2 = ls:unpack()
+  end
+
   love.graphics.line(x1, y1, x2, y2)
   playbit.graphics.updateContext()
 
+  module.setImageDrawMode(playbit.graphics.drawMode)
+end
+
+function module.drawPolygon(x1, y1, x2, y2, ...)
+  playbit.graphics.shader:send("mode", 8)
+
+  if type(x) ~= "number" then
+    local poly = x1
+    if poly:isClosed() then
+      love.graphics.polygon("line", unpack(poly._points))
+    else
+      love.graphics.line(unpack(poly._points))
+    end
+  else
+    love.graphics.polygon("line", x1, y1, x2, y2, ...)
+  end
+
+  playbit.graphics.updateContext()
   module.setImageDrawMode(playbit.graphics.drawMode)
 end
 
@@ -208,6 +255,11 @@ function module.drawArc(x, y, radius, startAngle, endAngle)
 
   local function normalizeAngle(deg)
       return (deg % 360 + 360) % 360
+  end
+
+  if type(x) ~= "number" then
+    local arc = x
+    x, y, radius, startAngle, endAngle = arc.x, arc.y, arc.radius, arc.startAngle, arc.endAngle
   end
 
   playbit.graphics.shader:send("mode", 8)

--- a/playdate/graphics.lua
+++ b/playdate/graphics.lua
@@ -24,6 +24,17 @@ module.kColorWhite = 1
 module.kColorBlack = 0
 -- TODO: clear and XOR support
 
+module.kStrokeCentered = 0
+module.kStrokeInside = 1
+module.kStrokeOutside = 2
+
+module.kLineCapStyleButt = 0
+module.kLineCapStyleSquare = 1
+module.kLineCapStyleRound = 2
+
+module.kPolygonFillNonZero = 0
+module.kPolygonFillEvenOdd = 1
+
 kTextAlignment = {
 	left = 0,
 	right = 1,
@@ -53,6 +64,10 @@ function module.setBackgroundColor(color)
   -- don't actually set love's bg color here since doing so immediately sets the color, and this is not consistent with PD
 end
 
+function module.getBackgroundColor(color)
+  return playbit.graphics.backgroundColorIndex
+end
+
 function module.setColor(color)
   @@ASSERT(color == 1 or color == 0, "Only values of 0 (black) or 1 (white) are supported.")
   playbit.graphics.drawColorIndex = color
@@ -72,6 +87,10 @@ function module.setColor(color)
   end
 end
 
+function module.getColor()
+  return playbit.graphics.drawColorIndex
+end
+
 function module.setPattern(pattern)
   playbit.graphics.drawPattern = pattern
 
@@ -87,8 +106,12 @@ function module.setPattern(pattern)
       end
     end
   end
-  
+
   playbit.graphics.shader:send("pattern", unpack(pixels))
+end
+
+function module.setDitherPattern(alpha, ditherType)
+  error("[ERR] playdate.graphics.setDitherPattern() is not yet implemented.")
 end
 
 function module.clear(color)
@@ -129,6 +152,10 @@ function module.setImageDrawMode(mode)
   end
 end
 
+function module.getImageDrawMode()
+  return playbit.graphics.drawMode
+end
+
 function module.drawCircleAtPoint(x, y, radius)
   playbit.graphics.shader:send("mode", 8)
 
@@ -147,8 +174,44 @@ function module.fillCircleAtPoint(x, y, radius)
   module.setImageDrawMode(playbit.graphics.drawMode)
 end
 
+function module.drawEllipseInRect(x, y, width, height, startAngle, endAngle)
+  error("[ERR] playdate.graphics.drawEllipseInRect() is not yet implemented.")
+end
+
+function module.fillEllipseInRect(x, y, width, height, startAngle, endAngle)
+  error("[ERR] playdate.graphics.fillEllipseInRect() is not yet implemented.")
+end
+
+function module.drawPolygon(x1, y1, x2, y2, ...)
+  error("[ERR] playdate.graphics.drawPolygon() is not yet implemented.")
+end
+
+function module.fillPolygon(x1, y1, x2, y2, ...)
+  error("[ERR] playdate.graphics.fillPolygon() is not yet implemented.")
+end
+
+function module.setPolygonFillRule(rule)
+  error("[ERR] playdate.graphics.setPolygonFillRule() is not yet implemented.")
+end
+
+function module.drawTriangle(x1, y1, x2, y2, x3, y3)
+  error("[ERR] playdate.graphics.drawTriangle() is not yet implemented.")
+end
+
+function module.fillTriangle(x1, y1, x2, y2, x3, y3)
+  error("[ERR] playdate.graphics.fillTriangle() is not yet implemented.")
+end
+
 function module.setLineWidth(width)
   love.graphics.setLineWidth(width)
+end
+
+function module.getLineWidth()
+  return love.graphics.getLineWidth()
+end
+
+function module.setLineCapStyle(style)
+  error("[ERR] playdate.graphics.setLineCapStyle() is not yet implemented.")
 end
 
 function module.drawRect(x, y, width, height)
@@ -230,6 +293,84 @@ function module.drawPixel(x, y)
   module.setImageDrawMode(playbit.graphics.drawMode)
 end
 
+function module.perlin(x, y, z, rep, octaves, persistence)
+  error("[ERR] playdate.graphics.perlin() is not yet implemented.")
+end
+
+function module.perlinArray(count, x, dx, y, dy, z, dz, rep, octaves, persistence)
+  error("[ERR] playdate.graphics.perlinArray() is not yet implemented.")
+end
+
+function module.generateQRCode(stringToEncode, desiredEdgeDimension, callback)
+  error("[ERR] playdate.graphics.generateQRCode() is not yet implemented.")
+end
+
+function module.drawSineWave(startX, startY, endX, endY, startAmplitude, endAmplitude, period, phaseShift)
+  error("[ERR] playdate.graphics.drawSineWave() is not yet implemented.")
+end
+
+function module.setClipRect(x, y, width, height)
+  error("[ERR] playdate.graphics.setClipRect() is not yet implemented.")
+end
+
+function module.getClipRect()
+  error("[ERR] playdate.graphics.getClipRect() is not yet implemented.")
+end
+
+function module.setScreenClipRect(x, y, width, height)
+  error("[ERR] playdate.graphics.setScreenClipRect() is not yet implemented.")
+end
+
+function module.getScreenClipRect()
+  error("[ERR] playdate.graphics.getScreenClipRect() is not yet implemented.")
+end
+
+function module.clearClipRect()
+  error("[ERR] playdate.graphics.clearClipRect() is not yet implemented.")
+end
+
+function module.setStencilImage(image, tile)
+  error("[ERR] playdate.graphics.setStencilImage() is not yet implemented.")
+end
+
+-- setStencilPattern(pattern)
+-- setStencilPattern(level, [ditherType])
+function module.setStencilPattern(row1, row2, row3, row4, row5, row6, row7, row8)
+  error("[ERR] playdate.graphics.setStencilPattern() is not yet implemented.")
+end
+
+function module.clearStencil()
+  error("[ERR] playdate.graphics.clearStencil() is not yet implemented.")
+end
+
+function module.clearStencilImage()
+  error("[ERR] playdate.graphics.clearStencilImage() is not yet implemented.")
+end
+
+function module.setStrokeLocation(location)
+  error("[ERR] playdate.graphics.setStrokeLocation() is not yet implemented.")
+end
+
+function module.getStrokeLocation()
+  error("[ERR] playdate.graphics.getStrokeLocation() is not yet implemented.")
+end
+
+function module.lockFocus(image)
+  error("[ERR] playdate.graphics.lockFocus() is not yet implemented.")
+end
+
+function module.unlockFocus()
+  error("[ERR] playdate.graphics.unlockFocus() is not yet implemented.")
+end
+
+function module.getDisplayImage()
+  error("[ERR] playdate.graphics.getDisplayImage() is not yet implemented.")
+end
+
+function module.getWorkingImage()
+  error("[ERR] playdate.graphics.getWorkingImage() is not yet implemented.")
+end
+
 function module.setFont(font)
   playbit.graphics.activeFont = font
   love.graphics.setFont(font.data)
@@ -237,6 +378,22 @@ end
 
 function module.getFont()
   return playbit.graphics.activeFont
+end
+
+function module.setFontFamily(fontFamily)
+  error("[ERR] playdate.graphics.setFontFamily() is not yet implemented.")
+end
+
+function module.setFontTracking(pixels)
+  error("[ERR] playdate.graphics.setFontTracking() is not yet implemented.")
+end
+
+function module.getFontTracking()
+  error("[ERR] playdate.graphics.getFontTracking() is not yet implemented.")
+end
+
+function module.getSystemFont(variant)
+  error("[ERR] playdate.graphics.getSystemFont() is not yet implemented.")
 end
 
 function module.getTextSize(str, fontFamily, leadingAdjustment)
@@ -247,7 +404,7 @@ function module.getTextSize(str, fontFamily, leadingAdjustment)
   return font:getWidth(str), font:getHeight()
 end
 
--- playdate.graphics.drawTextInRect(str, x, y, width, height, [leadingAdjustment, [truncationString, [alignment, [font]]]]) 
+-- playdate.graphics.drawTextInRect(str, x, y, width, height, [leadingAdjustment, [truncationString, [alignment, [font]]]])
 function module.drawTextInRect(text, x, ...)
   local y, width, height, leadingAdjustment, truncationString, textAlignment, font
   if type(x) == "number" then
@@ -317,7 +474,7 @@ function module.pushContext(image)
   if not image._canvas then
     image._canvas = love.graphics.newCanvas(image:getSize())
   end
-  
+
   -- push context
   table.insert(playbit.graphics.contextStack, image)
 

--- a/playdate/image.lua
+++ b/playdate/image.lua
@@ -78,6 +78,8 @@ function meta:draw(x, y, flip, qx, qy, qw, qh)
     end
   end
 
+  playbit.graphics.setDrawMode("image")
+
   if qx and qy and qw and qh then
     local w, h = self:getSize()
     playbit.graphics.quad:setViewport(qx, qy, qw, qh, w, h)
@@ -124,6 +126,8 @@ function meta:drawRotated(x, y, angle, scale, yscale)
   local sx = self.sx or 1
   local sy = self.sy or 1
 
+  playbit.graphics.setDrawMode("image")
+
   love.graphics.draw(self.data, x, y, math.rad(angle), sx, sy, w, h)
 
   playbit.graphics.updateContext()
@@ -141,6 +145,8 @@ function meta:drawScaled(x, y, scale, yscale)
 
   sx = sx * scale
   sy = sy * (yscale or scale)
+
+  playbit.graphics.setDrawMode("image")
 
   love.graphics.draw(self.data, x, y, 0, sx, sy)
 

--- a/playdate/image.lua
+++ b/playdate/image.lua
@@ -14,10 +14,16 @@ function module.new(widthOrPath, height, bgcolor)
   if height then
     -- creating empty image with dimensions
     local imageData = love.image.newImageData(widthOrPath, height)
-    img.data = love.graphics.newImage(imageData)  
+    img.data = love.graphics.newImage(imageData)
   else
     -- creating image from file
-    img.data = love.graphics.newImage(widthOrPath..".png")  
+    if love.filesystem.getInfo(widthOrPath..".png") then
+      img.data = love.graphics.newImage(widthOrPath..".png")
+    elseif love.filesystem.getInfo(widthOrPath) then
+      img.data = love.graphics.newImage(widthOrPath)
+    else
+      return nil
+    end
   end
 
   return img
@@ -65,7 +71,7 @@ function meta:draw(x, y, flip, qx, qy, qw, qh)
       y = y + h
     end
   end
-  
+
   if qx and qy and qw and qh then
     local w, h = self:getSize()
     playbit.graphics.quad:setViewport(qx, qy, qw, qh, w, h)

--- a/playdate/image.lua
+++ b/playdate/image.lua
@@ -91,8 +91,6 @@ function meta:draw(x, y, flip, qx, qy, qw, qh)
     end
     love.graphics.draw(self.data, x, y, 0, sx, sy)
   end
-
-  playbit.graphics.updateContext()
 end
 
 function meta:drawAnchored(x, y, ax, ay, flip)
@@ -129,8 +127,6 @@ function meta:drawRotated(x, y, angle, scale, yscale)
   playbit.graphics.setDrawMode("image")
 
   love.graphics.draw(self.data, x, y, math.rad(angle), sx, sy, w, h)
-
-  playbit.graphics.updateContext()
 end
 
 function meta:rotatedImage(angle, scale, yscale)
@@ -149,8 +145,6 @@ function meta:drawScaled(x, y, scale, yscale)
   playbit.graphics.setDrawMode("image")
 
   love.graphics.draw(self.data, x, y, 0, sx, sy)
-
-  playbit.graphics.updateContext()
 end
 
 function meta:scaledImage(scale, yscale)

--- a/playdate/image.lua
+++ b/playdate/image.lua
@@ -61,8 +61,7 @@ function meta:draw(x, y, flip, qx, qy, qw, qh)
   local sx = 1
   local sy = 1
   if flip then
-    local w = self.data:getWidth()
-    local h = self.data:getHeight()
+    local w, h = self:getSize()
     if flip == playdate.graphics.kImageFlippedX then
       sx = -1
       x = x + w
@@ -76,12 +75,16 @@ function meta:draw(x, y, flip, qx, qy, qw, qh)
       y = y + h
     end
   end
-  
+
   if qx and qy and qw and qh then
     local w, h = self:getSize()
     playbit.graphics.quad:setViewport(qx, qy, qw, qh, w, h)
-    love.graphics.draw(self.data, playbit.graphics.quad, x, y, sx, sy)
+    love.graphics.draw(self.data, playbit.graphics.quad, x, y, 0, sx, sy)
   else
+    if self.sx then
+      sx = sx * self.sx
+      sy = sy * self.sy
+    end
     love.graphics.draw(self.data, x, y, 0, sx, sy)
   end
 
@@ -114,7 +117,6 @@ function meta:drawRotated(x, y, angle, scale, yscale)
   love.graphics.setColor(1, 1, 1, 1)
 
   -- playdate.image.drawRotated() draws the texture centered, so emulate that
-  love.graphics.push()
   local w = self.data:getWidth() * 0.5
   local h = self.data:getHeight() * 0.5
 
@@ -122,10 +124,10 @@ function meta:drawRotated(x, y, angle, scale, yscale)
   w = math.floor(w)
   h = math.floor(h)
 
-  love.graphics.translate(x, y)
-  love.graphics.rotate(math.rad(angle))
-  love.graphics.draw(self.data, -w, -h)
-  love.graphics.pop()
+  local sx = self.sx or 1
+  local sy = self.sy or 1
+
+  love.graphics.draw(self.data, x, y, math.rad(angle), sx, sy, w, h)
 
   love.graphics.setColor(r, g, b, 1)
   playbit.graphics.updateContext()
@@ -142,11 +144,13 @@ function meta:drawScaled(x, y, scale, yscale)
   local r, g, b = love.graphics.getColor()
   love.graphics.setColor(1, 1, 1, 1)
 
-  love.graphics.push()
-  love.graphics.translate(x, y)
-  love.graphics.scale(scale, yscale)
-  love.graphics.draw(self.data, 0, 0)
-  love.graphics.pop()
+  local sx = self.sx or 1
+  local sy = self.sy or 1
+
+  sx = sx * scale
+  sy = sy * (yscale or scale)
+
+  love.graphics.draw(self.data, x, y, 0, sx, sy)
 
   love.graphics.setColor(r, g, b, 1)
   playbit.graphics.updateContext()

--- a/playdate/image.lua
+++ b/playdate/image.lua
@@ -28,11 +28,22 @@ function meta:load(path)
 end
 
 function meta:copy()
-  error("[ERR] playdate.graphics.image:copy() is not yet implemented.")
+  local img = setmetatable({}, meta)
+  img.data = self.data
+  img.sx = self.sx
+  img.sy = self.sy
+  return img
 end
 
 function meta:getSize()
-  return self.data:getWidth(), self.data:getHeight()
+  local w, h = self.data:getWidth(), self.data:getHeight()
+
+  if self.sx then
+    w = math.floor(w * self.sx)
+    h = math.floor(h * self.sy)
+  end
+
+  return w, h
 end
 
 function module.imageSizeAtPath(path)
@@ -142,7 +153,15 @@ function meta:drawScaled(x, y, scale, yscale)
 end
 
 function meta:scaledImage(scale, yscale)
-  error("[ERR] playdate.graphics.image:scaledImage() is not yet implemented.")
+  local img = self:copy()
+
+  local sx = img.sx or 1
+  local sy = img.sy or 1
+
+  img.sx = sx * scale
+  img.sy = sy * (yscale or scale)
+
+  return img
 end
 
 

--- a/playdate/image.lua
+++ b/playdate/image.lua
@@ -60,10 +60,6 @@ end
 -- (x, y, flip, sourceRect)
 -- (p, flip, sourceRect)
 function meta:draw(x, y, flip, qx, qy, qw, qh)
-  -- always render pure white so its not tinted
-  local r, g, b = love.graphics.getColor()
-  love.graphics.setColor(1, 1, 1, 1)
-
   local sx = 1
   local sy = 1
   if flip then
@@ -94,7 +90,6 @@ function meta:draw(x, y, flip, qx, qy, qw, qh)
     love.graphics.draw(self.data, x, y, 0, sx, sy)
   end
 
-  love.graphics.setColor(r, g, b, 1)
   playbit.graphics.updateContext()
 end
 
@@ -118,10 +113,6 @@ function meta:drawRotated(x, y, angle, scale, yscale)
   @@ASSERT(scale == nil, "[ERR] Parameter scale is not yet implemented.")
   @@ASSERT(yscale == nil, "[ERR] Parameter yscale is not yet implemented.")
 
-  -- always render pure white so its not tinted
-  local r, g, b = love.graphics.getColor()
-  love.graphics.setColor(1, 1, 1, 1)
-
   -- playdate.image.drawRotated() draws the texture centered, so emulate that
   local w = self.data:getWidth() * 0.5
   local h = self.data:getHeight() * 0.5
@@ -135,7 +126,6 @@ function meta:drawRotated(x, y, angle, scale, yscale)
 
   love.graphics.draw(self.data, x, y, math.rad(angle), sx, sy, w, h)
 
-  love.graphics.setColor(r, g, b, 1)
   playbit.graphics.updateContext()
 end
 
@@ -146,10 +136,6 @@ end
 function meta:drawScaled(x, y, scale, yscale)
   yscale = yscale or scale
 
-  -- always render pure white so its not tinted
-  local r, g, b = love.graphics.getColor()
-  love.graphics.setColor(1, 1, 1, 1)
-
   local sx = self.sx or 1
   local sy = self.sy or 1
 
@@ -158,7 +144,6 @@ function meta:drawScaled(x, y, scale, yscale)
 
   love.graphics.draw(self.data, x, y, 0, sx, sy)
 
-  love.graphics.setColor(r, g, b, 1)
   playbit.graphics.updateContext()
 end
 

--- a/playdate/lineSegment.lua
+++ b/playdate/lineSegment.lua
@@ -1,0 +1,107 @@
+local module = {}
+playdate.geometry.lineSegment = module
+
+local meta = {}
+meta.__index = meta
+module.__index = meta
+
+function module.new(x1, y1, x2, y2)
+  local o = {}
+
+  o._type = "lineSegment"
+  o.x1 = x1
+  o.y1 = y1
+  o.x2 = x2
+  o.y2 = y2
+
+  setmetatable(o, meta)
+  return o
+end
+
+function module.fast_intersection(x1, y1, x2, y2, x3, y3, x4, y4)
+  error("[ERR] playdate.geometry.lineSegment.fast_intersection() is not yet implemented.")
+end
+
+function meta:copy()
+  return module.new(self.x1, self.y1, self.x2, self.y2)
+end
+
+function meta:unpack()
+  return self.x1, self.y1, self.x2, self.y2
+end
+
+function meta:length()
+  local dx = self.x2 - self.x1
+  local dy = self.y2 - self.y1
+  return math.sqrt(dx * dx + dy * dy)
+end
+
+function meta:offset(dx, dy)
+  self.x1 = self.x1 + dx
+  self.x2 = self.x2 + dx
+  self.y1 = self.y1 + dy
+  self.y2 = self.y2 + dy
+end
+
+function meta:offsetBy(dx, dy)
+  return module.new(self.x1 + dx, self.y1 + dy, self.x2 + dx, self.y2 + dy)
+end
+
+function meta:midPoint()
+  return playdate.geometry.point.new((self.x1 + self.x2) / 2, (self.y1 + self.y2) / 2)
+end
+
+function meta:pointOnLine(distance, extend)
+  local len = self:length()
+  local d = distance / len
+
+  if not extend or extend ~= true then
+    if d < 0 then
+      d = 0
+    elseif d > 1 then
+      d = 1
+    end
+  end
+
+  local x = self.x1 + (self.x2 - self.x1) * d
+  local y = self.y1 + (self.y2 - self.y1) * d
+
+  return playdate.geometry.point.new(x, y)
+end
+
+-- TODO: Check what PD does here.
+function meta:segmentVector()
+  return playdate.geometry.vector2D.new(self.x2 - self.x1, self.y2 - self.y1)
+end
+
+function meta:closestPointOnLineToPoint(p, extend)
+  local vx = p.x - self.x1
+  local vy = p.y - self.y1
+
+  local dx = self.x2 - self.x1
+  local dy = self.y2 - self.y1
+
+  local d = (vx * dx + vy * dy) / (dx * dx + dy * dy)
+
+  if not extend or extend ~= true then
+    if d < 0 then
+      d = 0
+    elseif d > 1 then
+      d = 1
+    end
+  end
+
+  return playdate.geometry.point.new(self.x1 + d * dx, self.y1 + d * dy)
+end
+
+function meta:intersectsLineSegment(ls)
+  error("[ERR] playdate.geometry.lineSegment:intersectsLineSegment() is not yet implemented.")
+end
+
+function meta:intersectsPolygon(poly)
+  error("[ERR] playdate.geometry.lineSegment:intersectsPolygon() is not yet implemented.")
+end
+
+function meta:intersectsRect(rect)
+  error("[ERR] playdate.geometry.lineSegment:intersectsRect() is not yet implemented.")
+end

--- a/playdate/lineSegment.lua
+++ b/playdate/lineSegment.lua
@@ -1,3 +1,5 @@
+require("playbit.util")
+
 local module = {}
 playdate.geometry.lineSegment = module
 
@@ -53,16 +55,12 @@ end
 
 function meta:pointOnLine(distance, extend)
   local len = self:length()
-  local d = distance / len
 
-  if not extend or extend ~= true then
-    if d < 0 then
-      d = 0
-    elseif d > 1 then
-      d = 1
-    end
+  if not extend then
+    distance = playbit.util.clamp(distance, 0, len)
   end
 
+  local d = distance / len
   local x = self.x1 + (self.x2 - self.x1) * d
   local y = self.y1 + (self.y2 - self.y1) * d
 

--- a/playdate/math.lua
+++ b/playdate/math.lua
@@ -1,0 +1,6 @@
+local module = {}
+playdate.math = module
+
+function module.lerp(min, max, t)
+  return min + t * (max - min)
+end

--- a/playdate/playdate.lua
+++ b/playdate/playdate.lua
@@ -3,6 +3,7 @@ playdate = module
 
 require("playbit.geometry")
 require("playdate.metadata")
+require("playdate.math")
 require("playdate.sound")
 require("playdate.file")
 require("playdate.datastore")

--- a/playdate/playdate.lua
+++ b/playdate/playdate.lua
@@ -91,7 +91,7 @@ local JUST_RELEASED = 3
 local inputStates = {}
 
 function module.buttonIsPressed(button)
-  local key = module._buttonToKey[button]
+  local key = module._buttonToKey[string.lower(button)]
   if not inputStates[key] then
     -- no entry, assume no input
     return false
@@ -101,7 +101,7 @@ function module.buttonIsPressed(button)
 end
 
 function module.buttonJustPressed(button)
-  local key = module._buttonToKey[button]
+  local key = module._buttonToKey[string.lower(button)]
   if not inputStates[key] then
     -- no entry, assume no input
     return false
@@ -111,7 +111,7 @@ function module.buttonJustPressed(button)
 end
 
 function module.buttonJustReleased(button)
-  local key = module._buttonToKey[button]
+  local key = module._buttonToKey[string.lower(button)]
   if not inputStates[key] then
     -- no entry, assume no input
     return false
@@ -121,7 +121,7 @@ function module.buttonJustReleased(button)
 end
 
 function module.getButtonState(button)
-  local key = module._buttonToKey[button]
+  local key = module._buttonToKey[string.lower(button)]
   local value = inputStates[key]
   return value == PRESSED, value == PRESSED, value == JUST_RELEASED
 end

--- a/playdate/playdate.lua
+++ b/playdate/playdate.lua
@@ -11,11 +11,13 @@ require("playdate.json")
 
 -- ████████╗██╗███╗   ███╗███████╗
 -- ╚══██╔══╝██║████╗ ████║██╔════╝
---    ██║   ██║██╔████╔██║█████╗  
---    ██║   ██║██║╚██╔╝██║██╔══╝  
+--    ██║   ██║██╔████╔██║█████╗
+--    ██║   ██║██║╚██╔╝██║██╔══╝
 --    ██║   ██║██║ ╚═╝ ██║███████╗
 --    ╚═╝   ╚═╝╚═╝     ╚═╝╚══════╝
-                               
+
+local startTime = love.timer.getTime()
+
 function module.getTime()
   local seconds = os.time()
   local date = os.date("*t", seconds)
@@ -32,8 +34,76 @@ function module.getTime()
   }
 end
 
+function module.wait(milliseconds)
+  love.timer.sleep(milliseconds / 1000)
+end
+
+function module.stop()
+  error("[ERR] playdate.stop() is not yet implemented.")
+end
+
+function module.start()
+  error("[ERR] playdate.start() is not yet implemented.")
+end
+
+function module.restart(arg)
+  error("[ERR] playdate.restart() is not yet implemented.")
+end
+
+function module.restart()
+  error("[ERR] playdate.restart() is not yet implemented.")
+end
+
+function module.getSystemMenu()
+  error("[ERR] playdate.getSystemMenu() is not yet implemented.")
+end
+
+function module.setMenuImage(image, xOffset)
+  error("[ERR] playdate.setMenuImage() is not yet implemented.")
+end
+
+function module.getSystemLanguage()
+  error("[ERR] playdate.getSystemLanguage() is not yet implemented.")
+end
+
+function module.getReduceFlashing()
+  error("[ERR] playdate.getReduceFlashing() is not yet implemented.")
+end
+
+function module.getFlipped()
+  error("[ERR] playdate.getFlipped() is not yet implemented.")
+end
+
+function module.startAccelerometer()
+  error("[ERR] playdate.startAccelerometer() is not yet implemented.")
+end
+
+function module.stopAccelerometer()
+  error("[ERR] playdate.stopAccelerometer() is not yet implemented.")
+end
+
+function module.readAccelerometer()
+  error("[ERR] playdate.readAccelerometer() is not yet implemented.")
+end
+
+function module.accelerometerIsRunning()
+  error("[ERR] playdate.accelerometerIsRunning() is not yet implemented.")
+end
+
+function module.setAutoLockDisabled(disable)
+  error("[ERR] playdate.setAutoLockDisabled() is not yet implemented.")
+end
+
 function module.getCurrentTimeMilliseconds()
   return love.timer.getTime() * 1000
+end
+
+function module.resetElapsedTime()
+  startTime = love.timer.getTime()
+end
+
+function module.getElapsedTime()
+  return love.timer.getTime() - startTime
 end
 
 function module.getSecondsSinceEpoch()
@@ -55,13 +125,45 @@ function module.getSecondsSinceEpoch()
   return os.difftime(nowUtc, playdateEpochUtc), milliseconds
 end
 
+function module.getTime()
+  error("[ERR] playdate.getTime() is not yet implemented.")
+end
+
+function module.getGMTTime()
+  error("[ERR] playdate.getGMTTime() is not yet implemented.")
+end
+
+function module.epochFromTime(time)
+  error("[ERR] playdate.epochFromTime() is not yet implemented.")
+end
+
+function module.epochFromGMTTime(time)
+  error("[ERR] playdate.epochFromTime() is not yet implemented.")
+end
+
+function module.timeFromEpoch(seconds, milliseconds)
+  error("[ERR] playdate.timeFromEpoch() is not yet implemented.")
+end
+
+function module.GMTTimeFromEpoch(seconds, milliseconds)
+  error("[ERR] playdate.GMTTimeFromEpoch() is not yet implemented.")
+end
+
+function module.getServerTime(callback)
+  error("[ERR] playdate.getServerTime() is not yet implemented.")
+end
+
+function module.shouldDisplay24HourTime()
+  error("[ERR] playdate.shouldDisplay24HourTime() is not yet implemented.")
+end
+
 -- ██╗███╗   ██╗██████╗ ██╗   ██╗████████╗
 -- ██║████╗  ██║██╔══██╗██║   ██║╚══██╔══╝
--- ██║██╔██╗ ██║██████╔╝██║   ██║   ██║   
--- ██║██║╚██╗██║██╔═══╝ ██║   ██║   ██║   
--- ██║██║ ╚████║██║     ╚██████╔╝   ██║   
--- ╚═╝╚═╝  ╚═══╝╚═╝      ╚═════╝    ╚═╝   
-  
+-- ██║██╔██╗ ██║██████╔╝██║   ██║   ██║
+-- ██║██║╚██╗██║██╔═══╝ ██║   ██║   ██║
+-- ██║██║ ╚████║██║     ╚██████╔╝   ██║
+-- ╚═╝╚═╝  ╚═══╝╚═╝      ╚═════╝    ╚═╝
+
 local lastActiveJoystick = nil
 local isCrankDocked = false
 local crankPos = 0
@@ -126,6 +228,10 @@ function module.getButtonState(button)
   return value == PRESSED, value == PRESSED, value == JUST_RELEASED
 end
 
+function module.setButtonQueueSize(size)
+  error("[ERR] playdate.setButtonQueueSize() is not yet implemented.")
+end
+
 function module.isCrankDocked()
   if not lastActiveJoystick then
     return isCrankDocked
@@ -147,7 +253,7 @@ end
 function module.getCrankChange()
     local change = playbit.geometry.angleDiff(lastCrankPos, crankPos)
     -- TODO: how does the playdate accelerate this?
-    local acceleratedChange = change 
+    local acceleratedChange = change
     return change, acceleratedChange
 end
 
@@ -171,6 +277,14 @@ function module.getCrankPosition()
     return degrees + 360
   end
   return degrees
+end
+
+function module.getCrankTicks(ticksPerRevolution)
+  error("[ERR] playdate.getCrankTicks() is not yet implemented.")
+end
+
+function module.setCrankSoundsDisabled(disable)
+  error("[ERR] playdate.getCrankTicks() is not yet implemented.")
 end
 
 function love.joystickadded(joystick)
@@ -218,7 +332,7 @@ function love.wheelmoved(x, y)
   -- TODO: emulate PD crank acceleration?
   -- TODO: configure scroll sensitivity?
   crankPos = crankPos + -y * 6
-  
+
   if crankPos < 0 then
     crankPos = 359
   elseif crankPos > 359 then
@@ -289,7 +403,7 @@ function love.keypressed(key)
   end
 end
 
-function love.keyreleased(key)  
+function love.keyreleased(key)
   inputStates["kb_"..key] = JUST_RELEASED
 
   if playbit.keyReleased then
@@ -315,13 +429,25 @@ function module.updateInput()
   lastCrankPos = crankPos
 end
 
--- ██╗     ██╗   ██╗ █████╗ 
+function module.setNewlinePrinted(flag)
+  error("[ERR] playdate.setNewlinePrinted() is not yet implemented.")
+end
+
+function module.getFPS()
+  return love.timer.getFPS()
+end
+
+function module.drawFPS(x, y)
+  -- not implemented yet, but do not produce errors
+end
+
+-- ██╗     ██╗   ██╗ █████╗
 -- ██║     ██║   ██║██╔══██╗
 -- ██║     ██║   ██║███████║
 -- ██║     ██║   ██║██╔══██║
 -- ███████╗╚██████╔╝██║  ██║
 -- ╚══════╝ ╚═════╝ ╚═╝  ╚═╝
-                         
+
 function table.indexOfElement(table, element)
   for i = 1, #table do
     if table[i] == element then
@@ -340,6 +466,14 @@ function sample()
   error("[ERR] sample() is not yet implemented.")
 end
 
+function module.getStats()
+  error("[ERR] playdate.getStats() is not yet implemented.")
+end
+
+function module.setStatsInterval(seconds)
+  error("[ERR] playdate.setStatsInterval() is not yet implemented.")
+end
+
 function where()
   error("[ERR] where() is not yet implemented.")
 end
@@ -347,4 +481,36 @@ end
 function module.apiVersion()
   -- TODO: return Playbit version instead?
   error("[ERR] playdate.apiVersion() is not yet implemented.")
+end
+
+function module.getPowerStatus()
+  error("[ERR] playdate.getPowerStatus() is not yet implemented.")
+end
+
+function module.getBatteryPercentage()
+  error("[ERR] playdate.getBatteryPercentage() is not yet implemented.")
+end
+
+function module.getBatteryVoltage()
+  error("[ERR] playdate.getBatteryVoltage() is not yet implemented.")
+end
+
+function module.clearConsole()
+  error("[ERR] playdate.clearConsole() is not yet implemented.")
+end
+
+function module.setDebugDrawColor(r, g, b, a)
+  error("[ERR] playdate.setDebugDrawColor() is not yet implemented.")
+end
+
+function module.setCollectsGarbage(flag)
+  error("[ERR] playdate.setCollectsGarbage() is not yet implemented.")
+end
+
+function module.setMinimumGCTime(ms)
+  error("[ERR] playdate.setMinimumGCTime() is not yet implemented.")
+end
+
+function module.setGCScaling(min, max)
+  error("[ERR] playdate.setGCScaling() is not yet implemented.")
 end

--- a/playdate/playdate.lua
+++ b/playdate/playdate.lua
@@ -8,6 +8,7 @@ require("playdate.file")
 require("playdate.datastore")
 require("playdate.accelerometer")
 require("playdate.json")
+require("playdate.geometry")
 
 -- ████████╗██╗███╗   ███╗███████╗
 -- ╚══██╔══╝██║████╗ ████║██╔════╝

--- a/playdate/point.lua
+++ b/playdate/point.lua
@@ -1,0 +1,70 @@
+local module = {}
+playdate.geometry.point = module
+
+local meta = {}
+
+meta.__index = meta
+
+meta.__add = function(a, b)
+  return module.new(a.x + b.dx, a.y + b.dy)
+end
+
+meta.__sub = function(a, b)
+  if b._type then
+    if b._type == "point" then
+      return playdate.geometry.vector2D.new(a.x - b.x, a.y - b.y)
+    elseif b._type == "vector2D" then
+      return playdate.geometry.point.new(a.x - b.dx, a.y - b.dy)
+    end
+  end
+end
+
+meta.__mul = function(a, b)
+  return b:transformedPoint(a)
+end
+
+meta.__concat = function(a, b)
+  return playdate.geometry.lineSegment.new(a.x, a.y, b.x, b.y)
+end
+
+module.__index = meta
+
+function module.new(x, y)
+  local o = {}
+
+  o._type = "point"
+  o.x = x
+  o.y = y
+
+  setmetatable(o, meta)
+  return o
+end
+
+function meta:copy()
+  return module.new(self.x, self.y)
+end
+
+function meta:unpack()
+  return self.x, self.y
+end
+
+function meta:offset(dx, dy)
+  self.x = self.x + dx
+  self.y = self.y + dy
+end
+
+function meta:offsetBy(dx, dy)
+  return module.new(self.x + dx, self.y + dy)
+end
+
+function meta:squaredDistanceToPoint(p)
+  local dx = self.x - p.x
+  local dy = self.y - p.y
+  return dx * dx + dy * dy
+end
+
+function meta:distanceToPoint(p)
+  local dx = self.x - p.x
+  local dy = self.y - p.y
+  return math.sqrt(dx * dx + dy * dy)
+end

--- a/playdate/point.lua
+++ b/playdate/point.lua
@@ -27,6 +27,10 @@ meta.__concat = function(a, b)
   return playdate.geometry.lineSegment.new(a.x, a.y, b.x, b.y)
 end
 
+meta.__tostring = function(p)
+  return string.format("(%s, %s)", p.x, p.y)
+end
+
 module.__index = meta
 
 function module.new(x, y)

--- a/playdate/polygon.lua
+++ b/playdate/polygon.lua
@@ -1,0 +1,97 @@
+local module = {}
+playdate.geometry.polygon = module
+
+local meta = {}
+
+meta.__index = meta
+
+meta.__mul = function(a, b)
+  error("[ERR] playdate.geometry.polygon.__mul is not yet implemented.")
+end
+
+module.__index = meta
+
+function module.new(x1, y1, x2, y2, ...)
+  local o = {}
+
+  -- TODO !!!
+  error("[ERR] playdate.geometry.polygon.new() is not yet implemented.")
+
+  self._points = {}
+  self._closed = false
+
+  setmetatable(o, meta)
+  return o
+end
+
+function meta:copy()
+  local o = module.new(table.unpack(self._points))
+  o._closed = self._closed
+  return o
+end
+
+function meta:close()
+  self._closed = true
+end
+
+function meta:isClosed()
+  return self._closed
+end
+
+function meta:containsPoint(p, fillRule)
+  error("[ERR] playdate.geometry.polygon:containsPoint() is not yet implemented.")
+end
+
+function meta:containsPoint(x, y, fillRule)
+  error("[ERR] playdate.geometry.polygon:containsPoint() is not yet implemented.")
+end
+
+-- Returns multiple values (x, y, width, height) giving the axis-aligned bounding box for the polygon.
+function meta:getBounds()
+  error("[ERR] playdate.geometry.polygon:getBounds() is not yet implemented.")
+end
+
+function meta:getBoundsRect()
+  error("[ERR] playdate.geometry.polygon:getBoundsRect() is not yet implemented.")
+end
+
+-- Returns the number of points in the polygon.
+function meta:count()
+  return #self._points / 2
+end
+
+-- Returns the total length of all line segments in the polygon.
+function meta:length()
+  error("[ERR] playdate.geometry.polygon:length() is not yet implemented.")
+end
+
+function meta:setPointAt(n, x, y)
+  self._points[n * 2 + 1] = x
+  self._points[n * 2 + 2] = y
+end
+
+-- TODO: Check the return type because Playdate docs does not specify it.
+function meta:getPointAt(n)
+  return self._points[n * 2 + 1], self._points[n * 2 + 2]
+end
+
+function meta:intersects(p)
+  error("[ERR] playdate.geometry.polygon:intersects() is not yet implemented.")
+end
+
+function meta:pointOnPolygon(distance, extend)
+  error("[ERR] playdate.geometry.polygon:pointOnPolygon() is not yet implemented.")
+end
+
+function meta:translate(dx, dy)
+  local points = self._points
+  local len = #points
+  local i = 1
+
+  while i < len do
+    points[i] = points[i] + dx
+    i = i + 1
+    points[i] = points[i] + dy
+    i = i + 1
+  end
+end

--- a/playdate/polygon.lua
+++ b/playdate/polygon.lua
@@ -1,3 +1,6 @@
+require("playbit.vector")
+require("playbit.util")
+
 local module = {}
 playdate.geometry.polygon = module
 
@@ -11,14 +14,34 @@ end
 
 module.__index = meta
 
-function module.new(x1, y1, x2, y2, ...)
+function module.new(x1, y1, ...)
   local o = {}
 
-  -- TODO !!!
-  error("[ERR] playdate.geometry.polygon.new() is not yet implemented.")
+  o._type = "polygon"
+  o._points = {...}
+  o._closed = false
 
-  self._points = {}
-  self._closed = false
+  local pts = { }
+
+  if type(x1) == "number" then
+    if y1 then
+      pts = { x1, y1, ... }
+    else
+      local numberOfVertices = x1
+      for i = 1, numberOfVertices, 2 do
+        pts[i], pts[i + 1] = 0, 0
+      end
+    end
+  else
+    local args = {...}
+    for i = 1, #args do
+      local pt = args[i]
+      pts[i * 2 - 1] = pt.x
+      pts[i * 2]     = pt.y
+    end
+  end
+
+  o._points = pts
 
   setmetatable(o, meta)
   return o
@@ -32,6 +55,7 @@ end
 
 function meta:close()
   self._closed = true
+  self._length = nil
 end
 
 function meta:isClosed()
@@ -52,7 +76,8 @@ function meta:getBounds()
 end
 
 function meta:getBoundsRect()
-  error("[ERR] playdate.geometry.polygon:getBoundsRect() is not yet implemented.")
+  local x, y, w, h = self:getBounds()
+  return playdate.geometry.rect.new(x, y, w, h)
 end
 
 -- Returns the number of points in the polygon.
@@ -60,14 +85,39 @@ function meta:count()
   return #self._points / 2
 end
 
+local function calculateLength(pts, closed)
+  if #pts < 4 then return 0 end
+
+  local len = 0
+  local x1, y1 = pts[1], pts[2]
+
+  for i = 3, #pts, 2 do
+    local x2, y2 = pts[i], pts[i + 1]
+    len = len + playbit.vector.distance(x1, y1, x2, y2)
+    x1, y1 = x2, y2
+  end
+
+  if closed then
+    len = len + playbit.vector.distance(x1, y1, pts[1], pts[2])
+  end
+
+  return len
+end
+
 -- Returns the total length of all line segments in the polygon.
 function meta:length()
-  error("[ERR] playdate.geometry.polygon:length() is not yet implemented.")
+
+  if not self._length then
+    self._length = calculateLength(self._points, self._closed)
+  end
+
+  return self._length
 end
 
 function meta:setPointAt(n, x, y)
   self._points[n * 2 + 1] = x
   self._points[n * 2 + 2] = y
+  self._length = nil
 end
 
 -- TODO: Check the return type because Playdate docs does not specify it.
@@ -79,19 +129,68 @@ function meta:intersects(p)
   error("[ERR] playdate.geometry.polygon:intersects() is not yet implemented.")
 end
 
+local function pointOnLine(dist, len, x1, y1, x2, y2)
+  local d = dist / len
+  local x = x1 + (x2 - x1) * d
+  local y = y1 + (y2 - y1) * d
+  return playdate.geometry.point.new(x, y)
+end
+
 function meta:pointOnPolygon(distance, extend)
-  error("[ERR] playdate.geometry.polygon:pointOnPolygon() is not yet implemented.")
+  local pts = self._points
+
+  -- todo: Check what PD returns for 0 or 1 point polygons.
+  if #pts < 4 then return end
+
+  local length = self:length()
+
+  if not extend and not self._closed then
+    distance = playbit.util.clamp(distance, 0, length)
+  end
+
+  if self._closed then
+    -- Normalize distance making it positive.
+    distance = (distance % length + length) % length
+
+  else
+    -- Extrapolate the first segment.
+    if distance < 0 then
+      local x1, y1, x2, y2 = pts[1], pts[2], pts[3], pts[4]
+      local len = playbit.vector.distance(x1, y1, x2, y2)
+      return pointOnLine(distance, len, x1, y1, x2, y2)
+    end
+
+    -- Extrapolate the last segment.
+    if distance >= length then
+      local cnt = #pts
+      local x1, y1, x2, y2 = pts[cnt - 3], pts[cnt - 2], pts[cnt - 1], pts[cnt]
+      local len = playbit.vector.distance(x1, y1, x2, y2)
+      return pointOnLine(distance - length + len, len, x1, y1, x2, y2)
+    end
+  end
+
+  local x1, y1 = pts[1], pts[2]
+  local dist = distance
+  for i = 3, #pts, 2 do
+    local x2, y2 = pts[i], pts[i + 1]
+    local len = playbit.vector.distance(x1, y1, x2, y2)
+    if dist <= len and len > 1e-5 then
+      return pointOnLine(dist, len, x1, y1, x2, y2)
+    end
+    dist = dist - len
+    x1, y1 = x2, y2
+  end
+
+  local x2, y2 = pts[1], pts[2]
+  local len = playbit.vector.distance(x1, y1, x2, y2)
+  return pointOnLine(dist, len, x1, y1, x2, y2)
 end
 
 function meta:translate(dx, dy)
-  local points = self._points
-  local len = #points
-  local i = 1
-
-  while i < len do
-    points[i] = points[i] + dx
-    i = i + 1
-    points[i] = points[i] + dy
-    i = i + 1
+  local pts = self._points
+  for i = 1, #pts, 2 do
+    local j = i + 1
+    pts[i] = pts[i] + dx
+    pts[j] = pts[j] + dy
   end
 end

--- a/playdate/rect.lua
+++ b/playdate/rect.lua
@@ -1,0 +1,151 @@
+local module = {}
+playdate.geometry.rect = module
+
+local readonly_keys = { top = true, left = true, right = true, bottom = true }
+local meta = {}
+
+meta.__index = function(table, key)
+  if key == "top" then
+    return table.y
+
+  elseif key == "bottom" then
+    return table.y + table.height
+
+  elseif key == "left" then
+    return table.x
+
+  elseif key == "right" then
+    return table.x + table.width
+
+  elseif key == "size" then
+    return playdate.geometry.size.new(table.width, table.height)
+
+  else
+    return rawget(meta, key)
+
+  end
+end
+
+meta.__newindex = function(table, key, value)
+  if readonly_keys[key] then
+    error(string.format("field '%s' is read-only", key))
+
+  else
+    rawset(table, key, value)
+
+  end
+end
+
+module.__index = meta
+
+function module.new(x, y, width, height)
+  local o = {}
+
+  o._type = "rect"
+  o.x = x
+  o.y = y
+  o.width = width
+  o.height = height
+
+  setmetatable(o, meta)
+  return o
+end
+
+function meta:copy()
+  return module.new(self.x, self.y, self.width, self.height)
+end
+
+function meta:toPolygon()
+  local poly = playdategeometry.polygon.new(
+    self.x, self.y,
+    self.x + self.width, self.y,
+    self.x + self.width, self.y + self.height,
+    self.x, self.y + self.height)
+
+  poly:close()
+  return poly
+end
+
+function meta:unpack()
+  return self.x, self.y, self.width, self.height
+end
+
+function meta:isEmpty()
+  return self.width == 0 or self.height == 0
+end
+
+function meta:isEqual(r2)
+  local r1 = self
+  return r1.x == r2.x and r1.y == r2.y and r1.width == r2.width and r1.height == r2.height
+end
+
+function meta:intersects(r2)
+  local r1 = self
+  return r2.left <= r1.right and r2.right >= r1.left and r2.top <= r1.bottom and r2.bottom >= r1.top
+end
+
+function meta:intersection(r2)
+  local r1 = self
+  local left = math.max(r1.left, r2.left)
+  local right = math.min(r1.right, r2.right)
+  local top = math.max(r1.top, r2.top)
+  local bottom = math.min(r1.bottom, r2.bottom)
+
+  local width = math.max(0, right - left)
+  local height = math.max(1, bottom - top)
+
+  error("[ERR] playdate.geometry.rect:intersection() is not yet implemented.")
+end
+
+function meta:union(r2)
+  local r1 = self
+  local l = math.min(r1.left, r2.left)
+  local r = math.max(r1.right, r2.right)
+  local t = math.min(r1.top, r2.top)
+  local b = math.max(r1.bottom, r2.bottom)
+  return module.new(l, t, r - l, b - t)
+end
+
+function meta:inset(dx, dy)
+  self.x = self.x + dx
+  self.y = self.y + dy
+  self.width = self.width - dx - dx
+  self.height = self.height - dy - dy
+end
+
+function meta:insetBy(dx, dy)
+  return module.new(self.x + dx, self.y + dy, self.width - dx - dx, self.height - dy - dy)
+end
+
+function meta:offset(dx, dy)
+  self.x = self.x + dx
+  self.y = self.y + dy
+end
+
+function meta:offsetBy(dx, dy)
+  return module.new(self.x + dx, self.y + dy, self.width, self.height)
+end
+
+function meta:containsRect(xOrRect, y, width, height)
+  error("[ERR] playdate.geometry.rect:containsRect() is not yet implemented.")
+end
+
+function meta:containsPoint(xOrPoint, y)
+  local right = self.x + self.width
+  local bottom = self.y + self.height
+
+  if y then
+    return x >= self.x and x <= right and y >= self.y and y <= bottom
+  else
+    local p = xOrPoint
+    return p.x >= self.x and p.x <= right and p.y >= self.y and p.y <= bottom
+  end
+end
+
+function meta:centerPoint()
+  return playdate.geometry.point.new(self.x + self.width / 2, self.y + self.height / 2)
+end
+
+function meta:flipRelativeToRect(r2, flip)
+  error("[ERR] playdate.geometry.rect:flipRelativeToRect() is not yet implemented.")
+end

--- a/playdate/size.lua
+++ b/playdate/size.lua
@@ -1,0 +1,24 @@
+local module = {}
+playdate.geometry.size = module
+
+local meta = {}
+meta.__index = meta
+module.__index = meta
+
+function module.new(width, height)
+  local o = {}
+
+  o.width = width
+  o.height = height
+
+  setmetatable(o, meta)
+  return o
+end
+
+function meta:copy()
+  return module.new(self.width, self.height)
+end
+
+function meta:unpack()
+  return self.width, self.height
+end

--- a/playdate/tilemap.lua
+++ b/playdate/tilemap.lua
@@ -59,15 +59,22 @@ function meta:draw(x, y, sourceRect)
   local frameWidth = self._imagetable._frameWidth
   local frameHeight = self._imagetable._frameHeight
 
-  for i = 1, self._length do
-    local j = i - 1
-    local tile = self._tiles[i]
-    if tile > 0 then
-      -- TODO: fix - overwriting the parameter values x, y
-      local x = math.floor(j % self._width) * frameHeight
-      local y = math.floor(j / self._width) * frameWidth
-      love.graphics.draw(self._imagetable._images[tile].data, x, y)
+  local draw = love.graphics.draw
+  local images = self._imagetable._images
+  local index = 1
+  local sy = 0
+
+  for j = 1, self._height do
+    local sx = 0
+    for i = 1, self._width do
+      local tile = self._tiles[index]
+      if tile > 0 then
+        draw(images[tile].data, sx, sy)
+      end
+      sx = sx + frameWidth
+      index = index + 1
     end
+    sy = sy + frameHeight
   end
 
   love.graphics.setColor(r, g, b, 1)

--- a/playdate/tilemap.lua
+++ b/playdate/tilemap.lua
@@ -74,8 +74,6 @@ function meta:draw(x, y, sourceRect)
     end
     sy = sy + frameHeight
   end
-
-  playbit.graphics.updateContext()
 end
 
 function meta:getTiles()

--- a/playdate/tilemap.lua
+++ b/playdate/tilemap.lua
@@ -34,6 +34,9 @@ function meta:setTileAtPosition(x, y, index)
 end
 
 function meta:getTileAtPosition(x, y)
+  if x < 1 or x > self._width or y < 1 or y > self._height then
+    return nil
+  end
   local index = (y - 1) * self._width + x
   if index > #self._tiles then
     return 0

--- a/playdate/tilemap.lua
+++ b/playdate/tilemap.lua
@@ -59,14 +59,15 @@ function meta:draw(x, y, sourceRect)
 
   local draw = love.graphics.draw
   local images = self._imagetable._images
+  local tiles = self._tiles
   local index = 1
   local sy = y
 
   for j = 1, self._height do
     local sx = x
     for i = 1, self._width do
-      local tile = self._tiles[index]
-      if tile > 0 then
+      local tile = tiles[index]
+      if tile and tile > 0 then
         draw(images[tile].data, sx, sy)
       end
       sx = sx + frameWidth

--- a/playdate/tilemap.lua
+++ b/playdate/tilemap.lua
@@ -48,8 +48,6 @@ function meta:getTileAtPosition(x, y)
 end
 
 function meta:draw(x, y, sourceRect)
-  @@ASSERT(x == nil, "[ERR] Parameter x is not yet implemented.")
-  @@ASSERT(y == nil, "[ERR] Parameter y is not yet implemented.")
   @@ASSERT(sourceRect == nil, "[ERR] Parameter sourceRect is not yet implemented.")
 
   -- always render pure white so its not tinted
@@ -62,10 +60,10 @@ function meta:draw(x, y, sourceRect)
   local draw = love.graphics.draw
   local images = self._imagetable._images
   local index = 1
-  local sy = 0
+  local sy = y
 
   for j = 1, self._height do
-    local sx = 0
+    local sx = x
     for i = 1, self._width do
       local tile = self._tiles[index]
       if tile > 0 then

--- a/playdate/tilemap.lua
+++ b/playdate/tilemap.lua
@@ -60,6 +60,8 @@ function meta:draw(x, y, sourceRect)
   local index = 1
   local sy = y
 
+  playbit.graphics.setDrawMode("image")
+
   for j = 1, self._height do
     local sx = x
     for i = 1, self._width do

--- a/playdate/tilemap.lua
+++ b/playdate/tilemap.lua
@@ -50,10 +50,6 @@ end
 function meta:draw(x, y, sourceRect)
   @@ASSERT(sourceRect == nil, "[ERR] Parameter sourceRect is not yet implemented.")
 
-  -- always render pure white so its not tinted
-  local r, g, b = love.graphics.getColor()
-  love.graphics.setColor(1, 1, 1, 1)
-
   local frameWidth = self._imagetable._frameWidth
   local frameHeight = self._imagetable._frameHeight
 
@@ -77,7 +73,6 @@ function meta:draw(x, y, sourceRect)
     sy = sy + frameHeight
   end
 
-  love.graphics.setColor(r, g, b, 1)
   playbit.graphics.updateContext()
 end
 

--- a/playdate/tilemap.lua
+++ b/playdate/tilemap.lua
@@ -74,6 +74,7 @@ end
 
 function meta:setTiles(data, width)
   self._width = width
+  self._height = math.floor(#data / width)
   self._length = width * self._height
   self._tiles = data
 end

--- a/playdate/tilemap.lua
+++ b/playdate/tilemap.lua
@@ -34,7 +34,7 @@ function meta:setTileAtPosition(x, y, index)
 end
 
 function meta:getTileAtPosition(x, y)
-  local index = x * y
+  local index = (y - 1) * self._width + x
   if index > #self._tiles then
     return 0
   end

--- a/playdate/tilemap.lua
+++ b/playdate/tilemap.lua
@@ -59,6 +59,7 @@ function meta:draw(x, y, sourceRect)
 
   local draw = love.graphics.draw
   local images = self._imagetable._images
+  local imagesCount = #images
   local tiles = self._tiles
   local index = 1
   local sy = y
@@ -67,7 +68,7 @@ function meta:draw(x, y, sourceRect)
     local sx = x
     for i = 1, self._width do
       local tile = tiles[index]
-      if tile and tile > 0 then
+      if tile and tile > 0 and tile <= imagesCount then
         draw(images[tile].data, sx, sy)
       end
       sx = sx + frameWidth

--- a/playdate/tilemap.lua
+++ b/playdate/tilemap.lua
@@ -94,11 +94,11 @@ function meta:drawIgnoringOffset(x, y, sourceRect)
 end
 
 function meta:getSize()
-  error("[ERR] playdate.graphics.tilemap:getSize() is not yet implemented.")
+  return self._width, self._height
 end
 
 function meta:getPixelSize()
-  error("[ERR] playdate.graphics.tilemap:getPixelSize() is not yet implemented.")
+  return self._width * self._imagetable._frameWidth, self._height * self._imagetable._frameHeight
 end
 
 function meta:getCollisionRects(emptyIDs)

--- a/playdate/tilemap.lua
+++ b/playdate/tilemap.lua
@@ -56,10 +56,12 @@ function meta:draw(x, y, sourceRect)
   for i = 1, self._length do
     local j = i - 1
     local tile = self._tiles[i]
-    -- TODO: fix - overwriting the parameter values x, y
-    local x = math.floor(j % self._width) * frameHeight
-    local y = math.floor(j / self._width) * frameWidth
-    love.graphics.draw(self._imagetable._images[tile].data, x, y)
+    if tile > 0 then
+      -- TODO: fix - overwriting the parameter values x, y
+      local x = math.floor(j % self._width) * frameHeight
+      local y = math.floor(j / self._width) * frameWidth
+      love.graphics.draw(self._imagetable._images[tile].data, x, y)
+    end
   end
 
   love.graphics.setColor(r, g, b, 1)

--- a/playdate/tilemap.lua
+++ b/playdate/tilemap.lua
@@ -29,8 +29,11 @@ function meta:setSize(width, height)
   self._tiles = {}
 end
 
-function meta:setTileAtPosition(x, y, index)
-  self._tiles[x][y] = index -- index into the tilemap's imagetable
+function meta:setTileAtPosition(x, y, tile)
+  if x >= 1 and x <= self._width and y >= 1 and y <= self._height then
+    local index = (y - 1) * self._width + x
+    self._tiles[index] = tile -- index into the tilemap's imagetable
+  end
 end
 
 function meta:getTileAtPosition(x, y)

--- a/playdate/vector2D.lua
+++ b/playdate/vector2D.lua
@@ -1,0 +1,131 @@
+local module = {}
+playdate.geometry.vector2D = module
+
+local meta = {}
+meta.__index = meta
+
+meta.__unm = function(v)
+  return module.new(-v.dx, -v.dy)
+end
+
+meta.__add = function(v1, v2)
+  return module.new(v1.dx + v2.dx, v1.dy + v2.dy)
+end
+
+meta.__sub = function(v1, v2)
+  return module.new(v1.dx - v2.dx, v1.dy - v2.dy)
+end
+
+meta.__mul = function(v1, v2)
+  if type(v2) == "table" and v2._type then
+    if v2._type == "vector2D" then
+      return v1.dx * v2.dx + v1.dy * v2.dy
+
+    elseif v2._type == "affineTransform" then
+      return module.new(v1.dx * v2.m11 + v1.dy * v2.m12, v1.dx * v2.m21 + v1.dy * v2.m22)
+
+    end
+
+  else
+    local s = v2
+    return module.new(v1.dx * s, v1.dy * s)
+
+  end
+end
+
+meta.__div = function(v1, s)
+    return module.new(v1.dx / s, v1.dy / s)
+end
+
+module.__index = meta
+
+function module.new(dx, dy)
+  local o = {}
+
+  o._type = "vector2D"
+  o.dx = dx
+  o.dy = dy
+
+  setmetatable(o, meta)
+  return o
+end
+
+function module.newPolar(length, angle)
+  local o = {}
+
+  angle = angle * math.pi / 180
+
+  o._type = "vector2D"
+  o.dx =  length * math.sin(angle)
+  o.dy = -length * math.cos(angle)
+
+  setmetatable(o, meta)
+  return o
+end
+
+function meta:copy()
+  return module.new(self.dx, self.dy)
+end
+
+function meta:unpack()
+  return self.dx, self.dy
+end
+
+function meta:addVector(v)
+  self.dx = self.dx + v.dx
+  self.dy = self.dy + v.dy
+end
+
+function meta:scale(s)
+  self.dx = self.dx * s
+  self.dy = self.dy * s
+end
+
+function meta:scaledBy(s)
+  return module.new(self.dx * s, self.dy * s)
+end
+
+function meta:normalize()
+  local len = self:magnitude()
+  self.dx = self.dx / len
+  self.dy = self.dy / len
+end
+
+function meta:normalized()
+  local len = self:magnitude()
+  return module.new(self.dx / len, self.dy / len)
+end
+
+function meta:dotProduct(v)
+  return self.dx * v.dx + self.dy * v.dy
+end
+
+function meta:magnitude()
+  local dx, dy = self.dx, self.dy
+  return math.sqrt(dx * dx + dy * dy)
+end
+
+function meta:magnitudeSquared()
+  local dx, dy = self.dx, self.dy
+  return dx * dx + dy * dy
+end
+
+function meta:projectAlong(v)
+  error("[ERR] playdate.geometry.vector2D:projectAlong() is not yet implemented.")
+end
+
+function meta:projectedAlong(v)
+  error("[ERR] playdate.geometry.vector2D:projectedAlong() is not yet implemented.")
+end
+
+function meta:angleBetween(v)
+  error("[ERR] playdate.geometry.vector2D:angleBetween() is not yet implemented.")
+end
+
+function meta:leftNormal()
+  return module.new(self.dy, -self.dx)
+end
+
+function meta:rightNormal()
+  return module.new(-self.dy, self.dx)
+end


### PR DESCRIPTION
Resolves #64

This PR depends on graphics re-work of #91 

It contains two commits starting with 88f28b00

What was done:
1. Push context now stores all variables of the current graphics state.
2. Pop context restores the state. Example avaialble [here](https://sdk.play.date/inside-playdate/#f-graphics.popContext)
3. Made line width to be part of the graphics state.
4. Removed all calls to `updateContext()`