### PR TITLE
Fixes to animation.loop

### DIFF
--- a/playdate/animation.lua
+++ b/playdate/animation.lua
@@ -24,14 +24,14 @@ function module.new(delay, imageTable, shouldLoop)
   animation.shouldLoop = shouldLoop
 
   if imageTable then
-    animation.endFrame = imageTable:getLength()
+    animation.endFrame = #imageTable
   end
 
   return animation
 end
 
 function meta:image()
-  return self._imageTable:getImage(self.frame)
+  return self._imageTable[self.frame]
 end
 
 function meta:setImageTable(it)
@@ -65,7 +65,8 @@ function meta:draw(x, y, flip)
     end
   end
 
-  self._imageTable:drawImage(self.frame, x, y, flip)
+  local image = self._imageTable[self.frame]
+  image:draw(x, y, flip)
 end
 
 -- docs: https://sdk.play.date/2.6.2/Inside%20Playdate.html#C-graphics.animation.blinker

--- a/playdate/animation.lua
+++ b/playdate/animation.lua
@@ -20,6 +20,7 @@ local function updateFrame(self)
         self._startTime = playdate.getCurrentTimeMilliseconds()
       else
         self.frame = self.endFrame
+        self._valid = false
       end
     end
   end
@@ -38,6 +39,7 @@ function module.new(delay, imageTable, shouldLoop)
   animation.delay = delay or 100
   animation._imageTable = imageTable
   animation.shouldLoop = shouldLoop
+  animation._valid = true
 
   if imageTable then
     animation.endFrame = #imageTable
@@ -56,15 +58,7 @@ function meta:setImageTable(it)
 end
 
 function meta:isValid()
-  if self.shouldLoop then
-    return true
-  end
-
-  if self.frame > self.endFrame then
-    return false
-  end
-
-  return true
+  return self._valid
 end
 
 function meta:draw(x, y, flip)

--- a/playdate/animation.lua
+++ b/playdate/animation.lua
@@ -9,6 +9,22 @@ local meta = {}
 meta.__index = meta
 module.__index = meta
 
+local function updateFrame(self)
+  if not self.pause then
+    local elapsedTime = playdate.getCurrentTimeMilliseconds() - self._startTime
+    self.frame = self.startFrame + math.floor(elapsedTime / self.delay) * self.step
+
+    if self.frame > self.endFrame then
+      if self.shouldLoop then
+        self.frame = self.startFrame
+        self._startTime = playdate.getCurrentTimeMilliseconds()
+      else
+        self.frame = self.endFrame
+      end
+    end
+  end
+end
+
 function module.new(delay, imageTable, shouldLoop)
   local animation = setmetatable({}, meta)
   
@@ -31,6 +47,7 @@ function module.new(delay, imageTable, shouldLoop)
 end
 
 function meta:image()
+  updateFrame(self)
   return self._imageTable[self.frame]
 end
 
@@ -51,21 +68,7 @@ function meta:isValid()
 end
 
 function meta:draw(x, y, flip)
-  if not self.pause then
-    local elapsedTime = playdate.getCurrentTimeMilliseconds() - self._startTime
-    self.frame = self.startFrame + math.floor(elapsedTime / self.delay) * self.step
-
-    if self.frame > self.endFrame then
-      if self.shouldLoop then
-        self.frame = self.startFrame
-        self._startTime = playdate.getCurrentTimeMilliseconds()
-      else
-        self.frame = self.endFrame
-      end
-    end
-  end
-
-  local image = self._imageTable[self.frame]
+  local image = self:image()
   image:draw(x, y, flip)
 end
 

--- a/playdate/imagetable.lua
+++ b/playdate/imagetable.lua
@@ -4,11 +4,20 @@ local module = {}
 playdate.graphics.imagetable = module
 
 local meta = {}
-meta.__index = meta
-module.__index = meta
 
--- TODO: overload the `[]` array index operator to return an image
--- TODO: overload the `#` length operator to return the number of images
+meta.__index = function(table, key)
+  if type(key) == "number" then
+    return table:getImage(key)
+  else
+    return rawget(meta, key)
+  end
+end
+
+meta.__len = function(table)
+  return table.length
+end
+
+module.__index = meta
 
 -- TODO: handle overloaded signature (count, cellsWide, cellSize)
 function module.new(path, cellsWide, cellsSize)


### PR DESCRIPTION
1. In PD `animation.loop` allows array of images instead of imagetable because it uses only indexer `[]` and length `#` operators, so I allowed the same.
2. `animation.loop:image()` must update animation and return actual frame.
3. `animation.loop:isValid()` was not working properly and never returned `false`.